### PR TITLE
Input 컴포넌트 자동완성용 데이터 삽입 & 요소 선택 시 input에 입력값 저장하기 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <Typography variant='h1' color='primary.main'>
-        adfadfadf
+        Stackticon
       </Typography>
 
       <img height='32' width='32' src='https://cdn.simpleicons.org/react' />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
       <img height='32' width='32' src='https://cdn.simpleicons.org/javascript' />
       <img height='32' width='32' src='https://cdn.simpleicons.org/spring' />
 
-      <Home></Home>
+      <Home />
     </ThemeProvider>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@mui/material';
 import { ThemeProvider } from '@mui/system';
-import Input from 'components/input';
+import Home from 'pages/home';
 import { theme } from 'styles/theme';
 
 function App() {
@@ -8,13 +8,13 @@ function App() {
     <ThemeProvider theme={theme}>
       <Typography variant='h1' color='primary.main'>
         adfadfadf
-      </Typography>    
-    
+      </Typography>
+
       <img height='32' width='32' src='https://cdn.simpleicons.org/react' />
       <img height='32' width='32' src='https://cdn.simpleicons.org/javascript' />
       <img height='32' width='32' src='https://cdn.simpleicons.org/spring' />
 
-      <Input></Input>
+      <Home></Home>
     </ThemeProvider>
   );
 }

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,15 +1,28 @@
+import { useState } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
-import { Stacks } from 'mock/stacks';
+import { makeIconInfoArray } from 'utils/getAllIconInfo';
 
 const Input = () => {
+  const [selectedIconNames, setSelectedIconNames] = useState<string[]>([]);
+  const iconArr = makeIconInfoArray();
+
+  const onStackChange = (e: React.SyntheticEvent) => {
+    const { textContent } = e.currentTarget;
+    textContent && setSelectedIconNames((prev) => [...prev, textContent]);
+  };
+
   return (
     <div>
       <Autocomplete
-        disablePortal
-        id='combo-box-demo'
-        options={Stacks}
-        sx={{ width: 300 }}
-        renderInput={(params) => <TextField {...params} label='Stack' />}
+        multiple
+        id='tags-outlined'
+        options={iconArr}
+        getOptionLabel={(option) => option.title}
+        onChange={onStackChange}
+        filterSelectedOptions
+        renderInput={(params) => (
+          <TextField {...params} label='Choose User Stacks!' placeholder='Stacks' />
+        )}
       />
     </div>
   );

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,5 +1,11 @@
+import Input from 'components/input';
+
 const Home = () => {
-  return <></>;
+  return (
+    <>
+      <Input></Input>
+    </>
+  );
 };
 
 export default Home;

--- a/src/utils/getAllIconInfo.ts
+++ b/src/utils/getAllIconInfo.ts
@@ -2,15 +2,7 @@ import * as icons from 'simple-icons';
 
 import type { SimpleIcon } from 'simple-icons';
 
-const getAllIconInfo = () => {
-  if (icons) {
-    return icons;
-  }
-  throw new Error('에러가 발생했습니다. 아이콘 정보를 가져오지 못했습니다');
-};
-
 export const makeIconInfoArray = () => {
-  const iconObj = getAllIconInfo();
-  const iconArr: SimpleIcon[] = Object.values(iconObj);
+  const iconArr: SimpleIcon[] = Object.values(icons);
   return iconArr;
 };

--- a/src/utils/getAllIconInfo.ts
+++ b/src/utils/getAllIconInfo.ts
@@ -1,0 +1,16 @@
+import * as icons from 'simple-icons';
+
+import type { SimpleIcon } from 'simple-icons';
+
+const getAllIconInfo = () => {
+  if (icons) {
+    return icons;
+  }
+  throw new Error('에러가 발생했습니다. 아이콘 정보를 가져오지 못했습니다');
+};
+
+export const makeIconInfoArray = () => {
+  const iconObj = getAllIconInfo();
+  const iconArr: SimpleIcon[] = Object.values(iconObj);
+  return iconArr;
+};


### PR DESCRIPTION
## 📄 구현 내용 설명
- Input 컴포넌트 자동완성용 데이터를 삽입했습니다
- Input 창에서 요소를 선택할 시 input에 입력값이 계속 쌓이며 저장되게 구현했습니다

### ⛱️ 주요 변경 사항

- 컴포넌트와 하위 로직을 분리하기 위해 utils 폴더를 만들어 simple-icons를 가져와 배열로 변환해주는 코드를 작성했습니다.
- Autocomplete 태그에 filterSelectedOptions를 추가해 선택된 요소가 input에 쌓이게 만들었습니다.
- input에 쌓인 요소의 title을 selectedIconNames에 저장했습니다 @msdio 가  메인페이지를 구현할 때 쓸 수 있을 것 같습니다👍

### 🙋 이 부분을 리뷰해주세요

- utils 내부에 getAllIconInfo.ts를 삽입한 것이 적절한 구조인지 조금 의문이 듭니다
- import시 eslint 오류가(`Run autofix to sort these imports!eslint[simple-import-sort/imports](https://github.com/lydell/eslint-plugin-simple-import-sort#sort-order)`) 거듭 발생해 
```
    "simple-import-sort/imports": "error",
    "simple-import-sort/exports": "error",
```
이 부분을 주석 처리하고 진행했습니다. issue에 따로 작성하겠습니다
- `Encountered two children with the same key, `Handshake`` 에러가 발생합니다. 동일한 key를 가지고 있는 중첩되는 요소가 있는 것 같습니다. 이 내용도 issue에 작성하겠습니다!

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
