### PR TITLE
eslint 설정 수정, style에 black, white 색상 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,13 +11,7 @@
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended"
   ],
-  "plugins": [
-    "react",
-    "@typescript-eslint/eslint-plugin",
-    "import",
-    "simple-import-sort",
-    "unused-imports"
-  ],
+  "plugins": ["react", "@typescript-eslint/eslint-plugin", "simple-import-sort", "unused-imports"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": "latest",
@@ -56,52 +50,6 @@
       "error",
       {
         "prefer": "type-imports"
-      }
-    ],
-    "import/order": [
-      "error",
-      {
-        "groups": [
-          "builtin",
-          "external",
-          "internal",
-          ["sibling", "parent", "index"],
-          "type",
-          "unknown"
-        ],
-        "pathGroups": [
-          {
-            "pattern": "{react*,react*/**}",
-            "group": "external",
-            "position": "before"
-          },
-          {
-            "pattern": "pages/**/*.style",
-            "group": "unknown"
-          },
-          {
-            "pattern": "components/**/*.style",
-            "group": "unknown"
-          },
-          {
-            "pattern": "./**/*.style",
-            "group": "unknown"
-          },
-          {
-            "pattern": "../**/*.style",
-            "group": "unknown"
-          },
-          {
-            "pattern": ".style",
-            "group": "unknown"
-          }
-        ],
-        "pathGroupsExcludedImportTypes": ["react", "unknown"],
-        "newlines-between": "always",
-        "alphabetize": {
-          "order": "asc",
-          "caseInsensitive": true
-        }
       }
     ],
     "comma-spacing": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "eslint-config-prettier": "^8.6.0",
     "eslint-config-react": "^1.1.7",
     "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-simple-import-sort": "^10.0.0",

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,5 +1,7 @@
+import { AppBar } from '@mui/material';
+
 const Header = () => {
-  return <div></div>;
+  return <AppBar></AppBar>;
 };
 
 export default Header;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -22,5 +22,9 @@ export const theme = createTheme({
       main: '#D9E532',
       dark: '#99A419',
     },
+    common: {
+      black: '#191919',
+      white: '#F5F5F5',
+    },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4706,7 +4706,7 @@ eslint-plugin-flowtype@^8.0.3:
     lodash "^4.17.21"
     string-natural-compare "^3.0.1"
 
-eslint-plugin-import@^2.25.3, eslint-plugin-import@^2.27.5:
+eslint-plugin-import@^2.25.3:
   version "2.27.5"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz"
   integrity sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==


### PR DESCRIPTION
## 📄 구현 내용 설명
eslint 설정 수정, style에 black, white 색상 추가

### ⛱️ 주요 변경 사항

- 린트에서 기존에 충돌나던 `import`와 `simple-import-sort` 중에 전자를 삭제했습니다.
- theme.ts 파일에 common 색상을 추가했습니다. (black, white)

### 🙋 이 부분을 리뷰해주세요

-

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
