### PR TITLE
firebase 연결, storage에 업로드하고 받아오는 함수 제작

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
+import { useState } from 'react';
 import { makeIconInfoArray } from 'utils/getAllIconInfo';
 
 const Input = () => {

--- a/src/services/firebase/initialize.ts
+++ b/src/services/firebase/initialize.ts
@@ -1,0 +1,15 @@
+import { initializeApp } from 'firebase/app';
+import { getStorage } from 'firebase/storage';
+
+const firebaseConfig = {
+  apiKey: process.env.REACT_APP_API_KEY,
+  authDomain: process.env.REACT_APP_AUTHDOMAIN,
+  projectId: process.env.REACT_APP_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_APP_ID,
+  measurementId: process.env.REACT_APP_MEASUREMENT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const storage = getStorage(app);

--- a/src/services/firebase/storage.ts
+++ b/src/services/firebase/storage.ts
@@ -1,0 +1,29 @@
+import type { StorageReference } from 'firebase/storage';
+import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
+
+import { storage } from './initialize';
+
+const makeImageRef = (imageRef: string) => {
+  const baseRef = ref(storage, `images/${imageRef}`);
+  return baseRef;
+};
+
+export const downloadImageURL = async (downLoadRef: StorageReference) => {
+  const url = await getDownloadURL(downLoadRef);
+  if (url) {
+    return url;
+  }
+  throw new Error('에러가 발생했습니다. 이미지 주소를 받아오지 못했습니다');
+};
+
+export const uploadImageByBytes = async (
+  imageRef: string,
+  image: Blob | Uint8Array | ArrayBuffer,
+) => {
+  const stackImageRef = makeImageRef(imageRef);
+  const uploadRes = await uploadBytes(stackImageRef, image);
+  if (uploadRes) {
+    downloadImageURL(uploadRes.ref);
+  }
+  throw new Error('에러가 발생했습니다. 이미지를 생성하지 못했습니다');
+};

--- a/src/utils/getAllIconInfo.ts
+++ b/src/utils/getAllIconInfo.ts
@@ -1,6 +1,5 @@
-import * as icons from 'simple-icons';
-
 import type { SimpleIcon } from 'simple-icons';
+import * as icons from 'simple-icons';
 
 export const makeIconInfoArray = () => {
   const iconArr: SimpleIcon[] = Object.values(icons);


### PR DESCRIPTION
## 📄 구현 내용 설명
- firebase 연결, 초기화
- firebase storage에 이미지를 업로드하는 함수 제작
- firebase storage에서 이미지를 받아오는 함수 제작

### ⛱️ 주요 변경 사항
- services 내부의 firebase 폴더에서 작업
- initialize.ts로 firebase 초기화
- storage.ts로 storage 연동 작업 완료

### 🙋 이 부분을 리뷰해주세요
- 서비스 확장 예상 정도가 크지 않고 image 파일 / blob 파일 등 분기 처리를 할 필요가 없어서  받아오는 함수와 보내는 함수가 단 하나씩으로 해결 가능했습니다. 따라서 파일을 분리하지 않고 storage.ts 파일 안에서 보내고 받아오는 함수를 둘 다 생성했는데 괜찮은가요? + storage.ts 파일명은 괜찮은가요?
- Error을 보내는 부분을 상수로 만들어도 괜찮을 것 같다는 생각이 들었습니다. @msdio  생각은 어떤가요?

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
