### PR TITLE
Autocomplete option key error 해결

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
+import { useState } from 'react';
 import { makeIconInfoArray } from 'utils/getAllIconInfo';
 
 const Input = () => {
@@ -17,6 +17,13 @@ const Input = () => {
         multiple
         id='tags-outlined'
         options={iconArr}
+        renderOption={(props, option) => {
+          return (
+            <li {...props} key={option.path}>
+              {option.title}
+            </li>
+          );
+        }}
         getOptionLabel={(option) => option.title}
         onChange={onStackChange}
         filterSelectedOptions


### PR DESCRIPTION
## 📄 구현 내용 설명
mui Autocomplete 내부에 renderOption을 활용해서 key를 option.path로 지정
close #4 


### ⛱️ 주요 변경 사항
- input.tsx의 Autocomplete 내부에 renderOption 생성
-

### 🙋 이 부분을 리뷰해주세요

-
-

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
