### PR TITLE
Result 화면 view 구현

### DIFF
--- a/src/components/loading/Loading.tsx
+++ b/src/components/loading/Loading.tsx
@@ -1,15 +1,22 @@
 import Stacks from 'components/stacks';
-import { useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const Loading = () => {
+  const navigate = useNavigate();
   const targetRef = useRef<HTMLDivElement>(null);
   const { state } = useLocation();
-  console.log(state);
+
+  useEffect(() => {
+    if (state.length === 0) {
+      navigate('/');
+      // 깜빡거리는 issue 발생. cover component를 만들어서 해결 가능할거라 예상
+    }
+  }, []);
 
   return (
     <div>
-      <Stacks ref={targetRef} />
+      <Stacks ref={targetRef} selecteds={state} />
     </div>
   );
 };

--- a/src/components/stack/Stack.tsx
+++ b/src/components/stack/Stack.tsx
@@ -32,7 +32,7 @@ const Stack = ({ stackName }: StackProps) => {
           <path d={path} fill={`#${hex}`} />
         </SvgIcon>
       </div>
-      <p style={{ margin: '0' }}>{title}</p>
+      <p style={{ margin: '0', textAlign: 'center' }}>{title}</p>
     </div>
   );
 };

--- a/src/components/stack/Stack.tsx
+++ b/src/components/stack/Stack.tsx
@@ -7,14 +7,32 @@ interface StackProps {
 }
 
 const Stack = ({ stackName }: StackProps) => {
-  const { title, path } = getSimpleIconInfo(stackName);
-  return (
-    <div>
-      <SvgIcon>
-        <path d={path} />
-      </SvgIcon>
+  const { title, path, hex } = getSimpleIconInfo(stackName);
 
-      <p>{title}</p>
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+      }}
+    >
+      <div
+        style={{
+          borderRadius: '15%',
+          margin: '5px',
+          backgroundColor: 'white',
+          alignItems: 'center',
+          padding: '10px',
+          width: '70px',
+          height: '70px',
+        }}
+      >
+        <SvgIcon style={{ width: '50px', height: '50px' }} fill='white'>
+          <path d={path} fill={`#${hex}`} />
+        </SvgIcon>
+      </div>
+      <p style={{ margin: '0' }}>{title}</p>
     </div>
   );
 };

--- a/src/components/stacks/Stacks.tsx
+++ b/src/components/stacks/Stacks.tsx
@@ -21,7 +21,6 @@ const Stacks = forwardRef<HTMLDivElement, Props>(({ selecteds }, targetRef) => {
         <Stack key={select} stackName={select}></Stack>
       ))}
     </Box>
-    // </div>
   );
 });
 Stacks.displayName = 'Stacks';

--- a/src/components/stacks/Stacks.tsx
+++ b/src/components/stacks/Stacks.tsx
@@ -4,7 +4,17 @@ import React from 'react';
 const Stacks = React.forwardRef<HTMLDivElement>((props: any, targetRef) => {
   const stackArr = ['Javascript', 'React', 'Typescript'];
   return (
-    <div ref={targetRef}>
+    <div
+      ref={targetRef}
+      style={{
+        margin: '50px',
+        padding: '50px',
+        display: 'grid',
+        gridTemplateRows: '1fr ',
+        gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr',
+        backgroundColor: 'gray',
+      }}
+    >
       {stackArr.map((stack) => (
         <Stack key={stack} stackName={stack}></Stack>
       ))}

--- a/src/components/stacks/Stacks.tsx
+++ b/src/components/stacks/Stacks.tsx
@@ -1,24 +1,27 @@
+import { Box } from '@mui/material';
 import Stack from 'components/stack/Stack';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
-const Stacks = React.forwardRef<HTMLDivElement>((props: any, targetRef) => {
-  const stackArr = ['Javascript', 'React', 'Typescript'];
+interface Props {
+  selecteds: string[];
+}
+
+const Stacks = forwardRef<HTMLDivElement, Props>(({ selecteds }, targetRef) => {
   return (
-    <div
-      ref={targetRef}
-      style={{
-        margin: '50px',
-        padding: '50px',
-        display: 'grid',
-        gridTemplateRows: '1fr ',
-        gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr',
-        backgroundColor: 'gray',
-      }}
+    <Box
+      bgcolor='common.black'
+      display='grid'
+      gridTemplateRows='auto'
+      gridTemplateColumns='1fr 1fr 1fr 1fr 1fr 1fr'
+      color='common.white'
+      width='700px'
+      height='auto'
     >
-      {stackArr.map((stack) => (
-        <Stack key={stack} stackName={stack}></Stack>
+      {selecteds.map((select: string) => (
+        <Stack key={select} stackName={select}></Stack>
       ))}
-    </div>
+    </Box>
+    // </div>
   );
 });
 Stacks.displayName = 'Stacks';

--- a/src/pages/result/Result.tsx
+++ b/src/pages/result/Result.tsx
@@ -1,5 +1,16 @@
 const Result = () => {
-  return <></>;
+  const clickCopyUrl = () => {
+    console.log('temp');
+  };
+  return (
+    <div>
+      <div>image</div>
+      <div>
+        <button onClick={clickCopyUrl}>url 복사하기</button>
+        <button>다시 만들기</button>
+      </div>
+    </div>
+  );
 };
 
 export default Result;


### PR DESCRIPTION
## 📄 구현 내용 설명

### ⛱️ 주요 변경 사항
- Stack.tsx에 inline style이 추가되었습니다 
- Stacks.tsx에 inline style이 추가되었습니다 
- Result.tsx 페이지 outline을 잡아두었습니다
- 사용자가 stack을 선택하지 않고 생성 버튼을 누를 시 loding창에서 home('/')으로 리다이렉트시킵니다

### 🙋 이 부분을 리뷰해주세요
- 사용자가 stack을 선택하지 않고 생성 버튼을 누를 시 loding창에서 home('/')으로 리다이렉트시키는 과정에서 깜빡임이 발생합니다.
- 사용자가 직접 /loading 으로 접근했을 때 에러가 발생합니다.
- Loading 컴포넌트를 감싸는 LoadingContainer 컴포넌트를 제작해서 접근하는 방법을 생각했습니다
  - 직접 /loading에 접근할 때도 처리할 수 있고 아무것도 없는 배열이 넘어왔을 때의 깜빡임도 해결할 수 있을 것 같습니다
- 관련 내용 issue로 생성해 놓을게요😆

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
