### PR TITLE
Loading시 필요한 firebase와 html to image 로직 구현

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,15 +1,8 @@
-import { Autocomplete, TextField } from '@mui/material';
-import { useState } from 'react';
-import { makeIconInfoArray } from 'utils/getAllIconInfo';
+import { Autocomplete, SvgIcon, TextField } from '@mui/material';
+import { makeIconInfoArray } from 'utils/allIconInfo';
 
 const Input = () => {
-  const [selectedIconNames, setSelectedIconNames] = useState<string[]>([]);
   const iconArr = makeIconInfoArray();
-
-  const onStackChange = (e: React.SyntheticEvent) => {
-    const { textContent } = e.currentTarget;
-    textContent && setSelectedIconNames((prev) => [...prev, textContent]);
-  };
 
   return (
     <div>
@@ -20,15 +13,17 @@ const Input = () => {
         renderOption={(props, option) => {
           return (
             <li {...props} key={option.path}>
+              <SvgIcon>
+                <path d={option.path} />
+              </SvgIcon>
               {option.title}
             </li>
           );
         }}
         getOptionLabel={(option) => option.title}
-        onChange={onStackChange}
         filterSelectedOptions
         renderInput={(params) => (
-          <TextField {...params} label='Choose User Stacks!' placeholder='Stacks' />
+          <TextField {...params} label='Choose Your Stacks!' placeholder='Stacks' />
         )}
       />
     </div>

--- a/src/components/loading/Loading.tsx
+++ b/src/components/loading/Loading.tsx
@@ -1,11 +1,32 @@
 import Stacks from 'components/stacks';
-import { useRef } from 'react';
+import { toPng } from 'html-to-image';
+import { useEffect, useRef } from 'react';
+import { getCreatedImageUrl } from 'services/firebase/storage';
 
 const Loading = (props: any) => {
   const targetRef = useRef<HTMLDivElement>(null);
 
+  const getPngToImage = async () => {
+    if (targetRef.current === null) {
+      return;
+    }
+
+    const dataUrl = await toPng(targetRef.current, { cacheBust: true });
+    return dataUrl;
+  };
+
+  const makeResult = async () => {
+    const imageRef = await getPngToImage();
+    const resultUrl = await getCreatedImageUrl(imageRef!);
+    console.log(resultUrl);
+  };
+
+  useEffect(() => {
+    makeResult();
+  }, []);
   return (
     <div>
+      <div ref={targetRef}></div>
       <Stacks ref={targetRef} />
     </div>
   );

--- a/src/components/loading/Loading.tsx
+++ b/src/components/loading/Loading.tsx
@@ -1,9 +1,11 @@
 import Stacks from 'components/stacks';
 import { toPng } from 'html-to-image';
+import Page404 from 'pages/page404';
 import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { getCreatedImageUrl } from 'services/firebase/storage';
 
-const Loading = (props: any) => {
+const Loading = () => {
   const targetRef = useRef<HTMLDivElement>(null);
 
   const getPngToImage = async () => {
@@ -17,18 +19,25 @@ const Loading = (props: any) => {
 
   const makeResult = async () => {
     const imageRef = await getPngToImage();
-    const resultUrl = await getCreatedImageUrl(imageRef!);
+    const resultUrl = imageRef && (await getCreatedImageUrl(imageRef));
     console.log(resultUrl);
   };
 
   useEffect(() => {
     makeResult();
   }, []);
+  const { state } = useLocation();
+
   return (
-    <div>
-      <div ref={targetRef}></div>
-      <Stacks ref={targetRef} />
-    </div>
+    <>
+      {state === null || state.length === 0 ? (
+        <Page404 />
+      ) : (
+        <div>
+          <Stacks ref={targetRef} selecteds={state} />
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/loading/Loading.tsx
+++ b/src/components/loading/Loading.tsx
@@ -28,7 +28,6 @@ const Loading = () => {
   useEffect(() => {
     makeResult();
   }, []);
-  const { state } = useLocation();
 
   return (
     <>

--- a/src/services/firebase/storage.ts
+++ b/src/services/firebase/storage.ts
@@ -1,14 +1,16 @@
 import type { StorageReference } from 'firebase/storage';
+import { uploadString } from 'firebase/storage';
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
 
 import { storage } from './initialize';
 
-const makeImageRef = (imageRef: string) => {
-  const baseRef = ref(storage, `images/${imageRef}`);
+const makeImageRef = () => {
+  const miliseconds = new Date().getTime().toString();
+  const baseRef = ref(storage, `images/${miliseconds}`);
   return baseRef;
 };
 
-export const downloadImageURL = async (downLoadRef: StorageReference) => {
+const downloadImageURL = async (downLoadRef: StorageReference) => {
   const url = await getDownloadURL(downLoadRef);
   if (url) {
     return url;
@@ -16,14 +18,27 @@ export const downloadImageURL = async (downLoadRef: StorageReference) => {
   throw new Error('에러가 발생했습니다. 이미지 주소를 받아오지 못했습니다');
 };
 
-export const uploadImageByBytes = async (
-  imageRef: string,
-  image: Blob | Uint8Array | ArrayBuffer,
-) => {
-  const stackImageRef = makeImageRef(imageRef);
+const uploadImageByBytes = async (imageRef: string, image: Blob | Uint8Array | ArrayBuffer) => {
+  const stackImageRef = makeImageRef();
   const uploadRes = await uploadBytes(stackImageRef, image);
   if (uploadRes) {
-    downloadImageURL(uploadRes.ref);
+    return uploadRes;
   }
   throw new Error('에러가 발생했습니다. 이미지를 생성하지 못했습니다');
+};
+
+const uploadImageByString = async (imageRef: string) => {
+  const stackImageRef = makeImageRef();
+  const uploadRes = await uploadString(stackImageRef, imageRef, 'data_url');
+  if (uploadRes) {
+    return uploadRes;
+  }
+  throw new Error('에러가 발생했습니다. 이미지를 생성하지 못했습니다');
+};
+
+export const getCreatedImageUrl = async (imageRef: string) => {
+  const uploaded = await uploadImageByString(imageRef);
+  if (uploaded) {
+    return downloadImageURL(uploaded.ref);
+  }
 };


### PR DESCRIPTION
## 📄 구현 내용 설명

### ⛱️ 주요 변경 사항
- Loading.tsx에 makeResult 함수를 만들어 html에서 이미지로 변환하고 firebase에서 이미지의 경로를 받아오는 일련의 과정 구현
- Loading.tsx에 html to image를 이용하여 html을 png로 만드는 함수 구현( 관련 함수를 utils로 빼는 리팩토링이 필요할 것 같음!)
- html to image로 만들어진 image ref가 기존에 제작한 firebase 업로드 함수(bytes를 이용해 업로드하는 함수)와 충돌이 발생해 firebase 업로드 함수를 string으로 data_url을 이용해서 업로드로 변경
- 이미지 경로 덮어쓰기를 예방하기 위해 miliseconds를 이미지의 경로로 저장
- #20 사용자가 직접 /loading에 접근 시 에러가 발생하는 이슈를 page404로 리다이렉션시키는 방법으로 해결

### 🙋 이 부분을 리뷰해주세요
- 기존에 제작한 bytes를 이용해 업로드하는 함수를 제거하는게 좋을까요?
- html to png 함수를 utils 내부로 옮기는 것에 대한 의견이 궁금합니다 @msdio 

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
