### PR TITLE
Pretendard 폰트 글로벌 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@mui/system": "^5.11.8",
     "firebase": "^9.17.1",
     "html-to-image": "^1.11.11",
+    "pretendard": "^1.3.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.1",

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,25 @@
 import { createTheme } from '@mui/material/styles';
 
 export const theme = createTheme({
+  typography: {
+    fontFamily: [
+      'Pretendard Variable',
+      'Pretendard',
+      '-apple-system',
+      'BlinkMacSystemFont',
+      'system-ui',
+      'Roboto',
+      'Helvetica Neue',
+      'Segoe UI',
+      'Apple SD Gothic Neo',
+      'Noto Sans KR',
+      'Malgun Gothic',
+      'Apple Color Emoji',
+      'Segoe UI Emoji',
+      'Segoe UI Symbol',
+      'sans-serif',
+    ].join(','),
+  },
   palette: {
     primary: {
       light: '#FFFBF2',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8076,6 +8076,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
+pretendard@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/pretendard/-/pretendard-1.3.6.tgz#2441107c398053701d2730f51e2f24dce100e33f"
+  integrity sha512-JdImekU/moL3Qr+QqvFmZobYkwYQPA/8PoZ0ptOKNju+laE1xG9SxuxfpYLowfUeOcY+glQB6uINJsD5WAHFDw==
+
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz"


### PR DESCRIPTION
## 📄 구현 내용 설명
Pretendard 폰트를 전역에 적용했습니다.
아마 @userJu 가 걱정했던 404페이지쪽 폰트도 따로 거기에서 폰트 설정을 한게 아니라면 적용될거에요!

### ⛱️ 주요 변경 사항

- pretendard 설치
- MUI theme에 `typography` 속성 추가