### PR TITLE
input 창에서 생기던 delay 현상을 수정했습니다.

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,5 +1,5 @@
-import { Autocomplete, SvgIcon, TextField } from '@mui/material';
-import { useState } from 'react';
+import { Autocomplete, createFilterOptions, SvgIcon, TextField } from '@mui/material';
+import type { SimpleIcon } from 'simple-icons';
 
 import { makeIconInfoArray } from '../../utils/allIconInfo';
 
@@ -8,15 +8,13 @@ interface InputProps {
 }
 
 const Input = ({ handler }: InputProps) => {
-  const [selectedIconNames, setSelectedIconNames] = useState<string[]>([]);
   const iconArr = makeIconInfoArray();
 
-  const onStackChange = (e: React.SyntheticEvent, value: any) => {
-    const { textContent } = e.currentTarget;
-    textContent && setSelectedIconNames((prev) => [...prev, textContent]);
+  const onStackChange = (e: React.SyntheticEvent, value: SimpleIcon[]) => {
     handler(
       value.map(
-        (el: any) => el.slug.substring(0, 1).toUpperCase() + el.slug.substring(1, el.slug.length),
+        (el: SimpleIcon) =>
+          el.slug.substring(0, 1).toUpperCase() + el.slug.substring(1, el.slug.length),
       ),
     );
   };
@@ -30,7 +28,11 @@ const Input = ({ handler }: InputProps) => {
         renderOption={(props, option) => {
           return (
             <li {...props} key={option.path}>
-              <SvgIcon>
+              <SvgIcon
+                sx={{
+                  marginRight: '5px',
+                }}
+              >
                 <path d={option.path} />
               </SvgIcon>
               {option.title}
@@ -43,6 +45,9 @@ const Input = ({ handler }: InputProps) => {
         renderInput={(params) => (
           <TextField {...params} label='Choose Your Stacks!' placeholder='Stacks' />
         )}
+        filterOptions={createFilterOptions({
+          limit: 100,
+        })}
       />
     </div>
   );


### PR DESCRIPTION
close #15 

## 📄 구현 내용 설명
스택 검색 창에서 발생하던 딜레이 현상을 수정했습니다.

### ⛱️ 주요 변경 사항

- #15 에 코멘트 남긴 이후로 고민을 해봤는데요.. 발생 원인이 너무 많은 요소들을 dropdown에 그려서 생기는 현상인데, 그 개수를 줄이면 되지 않을까라는 아이디어에서 시작했습니다. 이렇게 아이디어가 정해지니 해결은 금방 됐어요.

- 완전 근본적인 해결책은 아니지만, 굳이 모든 메뉴들을 보여줄 필요가 없다고 판단해서 이렇게 해결했습니다.

- 생각해보면 저희가 dropdown에 사용하는 것들이 이미지가 아니라 svg인데.. 단순히 이미지 최적화 기법 이런걸 찾아보는건 의미가 없었네요..

- 추가로 기존에 결과 창에 보내기 위해 사용했었던 `selectedIconNames`와 관련 코드들을 제거했습니다!

### 🙋 이 부분을 리뷰해주세요

- [정답은 여기](https://github.com/msdio/stackticon/blob/17ef40daaa413b8541a0c9dd50d160460dc5ede2/src/components/input/Input.tsx#L48) 있습니다!

### 🤔 여기를 참고하면 도움이 돼요

-   [MUI filterOptions](https://mui.com/material-ui/react-autocomplete/#custom-filter)
