### PR TITLE
헤더에 로고들이 가려지는 현상 수정, 레이아웃 들에 컨텐츠 추가

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -9,12 +9,16 @@ const Container = styled.header`
 
   width: 100%;
   height: 80px;
-  background-color: #ddc6b6;
+  /* background-color: #ddc6b6; */
+  background-color: #02343f;
+  /* background-color: #343148; */
   padding: 10px 30px;
 
   position: fixed;
 
   z-index: 100;
+
+  border-radius: 0 0 10px 10px;
 `;
 
 const RouterLink = styled(RLink)`
@@ -69,7 +73,7 @@ const Header = () => {
           }}
         >
           <SvgIcon viewBox='0 0 512 512'>
-            <path d={Svg.coffee} />
+            <path d={Svg.coffee} fill='#FFF8EA' />
           </SvgIcon>
           <Typography color='primary.main'>buy coffee</Typography>
         </Box>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -100,13 +100,14 @@ const Home = () => {
         ref={containerRef}
         style={{
           width: '100vw !important',
-          height: '95vh',
+          height: 'calc(100vh - 80px)',
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
           gap: '10px',
           overflow: 'hidden',
           position: 'relative',
+          transform: 'translateY(80px)',
         }}
       >
         <Input handler={changeSkillSet} />
@@ -172,68 +173,85 @@ const Home = () => {
         </MotionDiv>
       </div>
 
-      <Container
-        sx={{
+      <div
+        style={{
           width: '100%',
-          height: '50vh',
-          display: 'flex',
-          justifyContent: 'space-evenly',
-          alignItems: 'center',
-          gap: '10px',
+          height: '100vh',
         }}
       >
-        <Box
+        <Container
           sx={{
-            animation: scroll ? `${fadeFromLeft} 1s` : '',
-            display: scroll ? '' : 'none',
+            width: '100%',
+            height: '50vh',
+            display: 'flex',
+            justifyContent: 'space-evenly',
+            alignItems: 'center',
+            gap: '10px',
           }}
         >
-          <Typography variant='h4'>Simple, Fast</Typography>
-          <Typography marginLeft={5} marginTop={1}>
-            just input your skills and get it
-          </Typography>
-        </Box>
-        <Box
-          sx={{
-            width: '450px',
-            height: '300px',
-            background: 'grey',
-            animation: scroll ? `${fadeFromRight} 1s` : '',
-            display: scroll ? '' : 'none',
-          }}
-        />
-      </Container>
-      <Container
-        sx={{
-          width: '100%',
-          height: '50vh',
-          display: 'flex',
-          justifyContent: 'space-evenly',
-          alignItems: 'center',
-          gap: '10px',
-        }}
-      >
-        <Box
-          sx={{
-            width: '500px',
-            height: '350px',
-            background: 'grey',
-            animation: scroll ? `${fadeFromLeft} 1s` : '',
-            display: scroll ? '' : 'none',
-          }}
-        />
-        <Box>
-          <Typography
-            variant='h4'
+          <Box
             sx={{
+              animation: scroll ? `${fadeFromLeft} 1s` : '',
+              display: scroll ? '' : 'none',
+            }}
+          >
+            <Typography variant='h4'>Simple, Fast</Typography>
+            <Typography marginLeft={5} marginTop={1}>
+              just input your skills and get it
+            </Typography>
+          </Box>
+          <Box
+            sx={{
+              width: '550px',
               animation: scroll ? `${fadeFromRight} 1s` : '',
               display: scroll ? '' : 'none',
             }}
           >
-            Recognize in a glance
-          </Typography>
-        </Box>
-      </Container>
+            <img
+              width='550px'
+              src='https://user-images.githubusercontent.com/59170680/219634902-3ba561ac-cc65-4e1f-aff7-310fd100266e.gif'
+              alt='choose stacks gif'
+              loading='lazy'
+            />
+          </Box>
+        </Container>
+        <Container
+          sx={{
+            width: '100%',
+            height: '40vh',
+            display: 'flex',
+            justifyContent: 'space-evenly',
+            alignItems: 'center',
+            gap: '10px',
+          }}
+        >
+          <Box
+            sx={{
+              width: '500px',
+              animation: scroll ? `${fadeFromLeft} 1s` : '',
+              display: scroll ? '' : 'none',
+            }}
+          >
+            <img
+              width='500px'
+              src='https://user-images.githubusercontent.com/59170680/219640020-46b1972a-968d-495d-8f82-00bb90f03357.png'
+              alt='create your own skill sets'
+              loading='lazy'
+            />
+          </Box>
+          <Box>
+            <Typography
+              variant='h4'
+              sx={{
+                animation: scroll ? `${fadeFromRight} 1s` : '',
+                display: scroll ? '' : 'none',
+              }}
+            >
+              Recognize in a glance
+            </Typography>
+          </Box>
+        </Container>
+      </div>
     </CustomContainer>
   );
 };


### PR DESCRIPTION
## 📄 구현 내용 설명
<img width="612" alt="Screenshot 2023-02-17 at 8 56 58 PM" src="https://user-images.githubusercontent.com/59170680/219647836-2cf582c9-d341-4d50-94ff-46f780b9d22c.png">
<img width="613" alt="Screenshot 2023-02-17 at 8 57 27 PM" src="https://user-images.githubusercontent.com/59170680/219647953-a359b6ba-b3a8-46bf-b490-ccbda054f77c.png">

### ⛱️ 주요 변경 사항

- 헤더에 로고들이 가려지던 현상을 수정했습니다.
- 메인 화면 하단에 gif와 사진을 추가했습니다.

### 🙋 이 부분을 리뷰해주세요

- 헤더 색상이 너무 마음에 안들어서 수정해봤는데, 어떤가요?

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
