### PR TITLE
loading과 result 페이지에 직접 접근 시 에러를 수정했습니다

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,4 +1,5 @@
 import Loading from 'components/loading';
+import RequireState from 'components/requireState';
 import Home from 'pages/home';
 import Cute404 from 'pages/page404/Cute404';
 import Result from 'pages/result';
@@ -7,9 +8,8 @@ import { Route, Routes } from 'react-router-dom';
 const Router = () => (
   <Routes>
     <Route path='/' element={<Home />} />
-    <Route path='/loading' element={<Loading />} />
-
-    <Route path='/result' element={<Result />} />
+    <Route path='/loading' element={<RequireState component={<Loading />} />} />
+    <Route path='/result' element={<RequireState component={<Result />} />} />
     <Route path='*' element={<Cute404 />} />
   </Routes>
 );

--- a/src/components/loading/Loading.tsx
+++ b/src/components/loading/Loading.tsx
@@ -1,5 +1,4 @@
 import Stacks from 'components/stacks';
-import Cute404 from 'pages/page404/Cute404';
 import { useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { getCreatedImageUrl } from 'services/firebase/storage';
@@ -30,15 +29,9 @@ const Loading = () => {
   }, []);
 
   return (
-    <>
-      {state === null || state.length === 0 ? (
-        <Cute404 />
-      ) : (
-        <div>
-          <Stacks ref={targetRef} selecteds={state} />
-        </div>
-      )}
-    </>
+    <div>
+      <Stacks ref={targetRef} selecteds={state} />
+    </div>
   );
 };
 

--- a/src/components/requireState/RequireState.tsx
+++ b/src/components/requireState/RequireState.tsx
@@ -1,0 +1,18 @@
+import Cute404 from 'pages/page404';
+import { useLocation } from 'react-router';
+
+interface RequireStateProps {
+  component: JSX.Element;
+}
+
+const RequireState = ({ component }: RequireStateProps) => {
+  const { state } = useLocation();
+
+  if (!state) {
+    return <Cute404 />;
+  }
+
+  return component;
+};
+
+export default RequireState;

--- a/src/components/requireState/index.ts
+++ b/src/components/requireState/index.ts
@@ -1,0 +1,3 @@
+import RequireState from './RequireState';
+
+export default RequireState;


### PR DESCRIPTION
## 📄 구현 내용 설명
- result 페이지에 직접 접근 시 404 페이지로 리다이렉트 시켜줍니다
- RequireState404 컴포넌트를 만들어 state가 필요한 loading, result 페이지의 경우 state의 유무에 따라 404 페이지 / loading, result 페이지가 보이게 만들었습니다 close #20 

### ⛱️ 주요 변경 사항
- Loading.tsx창에서 state의 유무를 확인하고 Cute404 페이지로 리다이렉트시키던 기존 코드
```
 return (
    <>
      {state === null || state.length === 0 ? (
        <Cute404 />
      ) : (
        <div>
          <Stacks ref={targetRef} selecteds={state} />
        </div>
      )}
    </>
  );
```
에서

```
  return (
    <div>
      <Stacks ref={targetRef} selecteds={state} />
    </div>
```

로 변했습니다. 

Loading.tsx 페이지가 하는 역할에서 state가 없을 시 404 페이지를 보여주는 부분을 분리함으로써 컴포넌트의 역할을 제한했습니다.

### 🙋 이 부분을 리뷰해주세요
- state가 있을 경우에만 원하는 페이지로 옮겨준다는 의미에서 RequireState라는 이름을 사용했는데 역할 추론이 쉬운 이름일까요?
- @msdio 는 이 부분을 어떻게 구현했을 것 같나요?! 더 다양한 방법이 있는 것 같아 궁금해서 물어봅니다! 

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
