### PR TITLE
add copy options on result page

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@mui/icons-material": "^5.11.9",
     "@mui/material": "^5.11.8",
     "@mui/system": "^5.11.8",
     "firebase": "^9.17.1",

--- a/src/components/button-options/ButtonOptions.tsx
+++ b/src/components/button-options/ButtonOptions.tsx
@@ -1,0 +1,118 @@
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import {
+  Button,
+  ButtonGroup,
+  ClickAwayListener,
+  Grow,
+  MenuItem,
+  MenuList,
+  Paper,
+  Popper,
+} from '@mui/material';
+import { Fragment, useRef, useState } from 'react';
+import { makeUrlIntoBracket, makeUrlIntoImgTag } from 'utils/resultUrl';
+
+const copyOptions = ['copy for readme', 'copy link only', 'copy img tag'];
+
+const ButtonOptions = (state: any) => {
+  const [openOptions, setOpenOptions] = useState(false);
+  const [selectedOption, setSelectedOption] = useState(0);
+  const buttonRef = useRef<HTMLDivElement>(null);
+
+  const bracketUrl = makeUrlIntoBracket(state.url);
+  const imgTagUrl = makeUrlIntoImgTag(state.url);
+
+  const clickCopyUrl = async () => {
+    const selected = copyOptions[selectedOption];
+    let copyText = '';
+
+    if (selected.includes('readme')) {
+      copyText = bracketUrl;
+    } else if (selected.includes('tag')) {
+      copyText = imgTagUrl;
+    } else {
+      copyText = state.url;
+    }
+    await navigator.clipboard.writeText(copyText);
+    alert('copied!');
+  };
+
+  const clickCopyOption = (e: React.MouseEvent<HTMLLIElement, MouseEvent>, index: number) => {
+    setSelectedOption(index);
+    setOpenOptions(false);
+  };
+
+  const handleToggle = () => {
+    setOpenOptions((prev) => !prev);
+  };
+
+  const handleClose = (e: Event) => {
+    if (buttonRef.current && buttonRef.current.contains(e.target as HTMLElement)) {
+      return;
+    }
+
+    setOpenOptions(false);
+  };
+
+  return (
+    <Fragment>
+      <ButtonGroup
+        ref={buttonRef}
+        aria-label='button with options'
+        style={{ marginRight: '10px' }}
+        variant='contained'
+        color='success'
+      >
+        <Button onClick={clickCopyUrl}>{copyOptions[selectedOption]}</Button>
+        <Button
+          size='small'
+          aria-controls={openOptions ? 'split-button-menu' : undefined}
+          aria-expanded={openOptions ? 'true' : undefined}
+          aria-label='select copy options'
+          aria-haspopup='menu'
+          onClick={handleToggle}
+        >
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
+
+      <Popper
+        sx={{
+          zindex: 1,
+        }}
+        open={openOptions}
+        anchorEl={buttonRef.current}
+        role={undefined}
+        transition
+        disablePortal
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
+            }}
+          >
+            <Paper>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList id='split-button-menu' autoFocusItem>
+                  {copyOptions.map((option, index) => (
+                    <MenuItem
+                      key={option}
+                      selected={index === selectedOption}
+                      onClick={(e) => clickCopyOption(e, index)}
+                    >
+                      {option}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </Fragment>
+  );
+};
+
+export default ButtonOptions;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -62,7 +62,7 @@ const Header = () => {
           </Box>
         </Link>
 
-        <Box
+        {/* <Box
           component='div'
           sx={{
             display: 'flex',
@@ -75,7 +75,7 @@ const Header = () => {
             <path d={Svg.coffee} fill='#FFF8EA' />
           </SvgIcon>
           <Typography color='primary.main'>buy coffee</Typography>
-        </Box>
+        </Box> */}
       </Stack>
     </Container>
   );

--- a/src/components/requireState/RequireState.tsx
+++ b/src/components/requireState/RequireState.tsx
@@ -1,16 +1,13 @@
-import Cute404 from 'pages/page404';
-import { useLocation } from 'react-router';
-
 interface RequireStateProps {
   component: JSX.Element;
 }
 
 const RequireState = ({ component }: RequireStateProps) => {
-  const { state } = useLocation();
+  // const { state } = useLocation();
 
-  if (!state) {
-    return <Cute404 />;
-  }
+  // if (!state) {
+  //   return <Cute404 />;
+  // }
 
   return component;
 };

--- a/src/components/requireState/RequireState.tsx
+++ b/src/components/requireState/RequireState.tsx
@@ -1,13 +1,16 @@
+import Cute404 from 'pages/page404';
+import { useLocation } from 'react-router-dom';
+
 interface RequireStateProps {
   component: JSX.Element;
 }
 
 const RequireState = ({ component }: RequireStateProps) => {
-  // const { state } = useLocation();
+  const { state } = useLocation();
 
-  // if (!state) {
-  //   return <Cute404 />;
-  // }
+  if (!state) {
+    return <Cute404 />;
+  }
 
   return component;
 };

--- a/src/pages/result/Result.tsx
+++ b/src/pages/result/Result.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { Button, Typography } from '@mui/material';
+import ButtonOptions from 'components/button-options/ButtonOptions';
 import { APP_NAME } from 'constants/constants';
 import { Link, useLocation } from 'react-router-dom';
 
@@ -23,31 +24,20 @@ const Buttons = styled.div`
 
 const Result = () => {
   const { state } = useLocation();
-  const clickCopyUrl = async () => {
-    await navigator.clipboard.writeText(state);
-    alert('url을 복사했습니다');
-  };
+
   return (
     <Container>
       <Typography marginBottom={'10%'} fontWeight={'bold'} color={'#02343f'} variant='h1'>
         {APP_NAME}
       </Typography>
       <div>
-        <Img src={state} alt='' />
+        <Img src={state} alt='stackticon result' />
       </div>
       <Buttons>
-        <Button
-          style={{ marginRight: '10px' }}
-          onClick={clickCopyUrl}
-          variant='contained'
-          color='success'
-          startIcon='🍄'
-        >
-          url 복사하기
-        </Button>
+        <ButtonOptions url={state} />
         <Link to='/' style={{ textDecoration: 'none' }}>
           <Button style={{ marginLeft: '10px' }} variant='contained' color='info' endIcon='🏠'>
-            메인으로
+            Return to main
           </Button>
         </Link>
       </Buttons>

--- a/src/utils/resultUrl.ts
+++ b/src/utils/resultUrl.ts
@@ -1,0 +1,7 @@
+export const makeUrlIntoBracket = (url: string) => {
+  return `[![stackticon](${url})](https://github.com/msdio/stackticon)`;
+};
+
+export const makeUrlIntoImgTag = (url: string) => {
+  return `<a href="https://github.com/msdio/stackticon"><img src="${url}" alt="stackticon" /></a>`;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1034,7 +1034,7 @@
   resolved "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.20.13"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz"
   integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
@@ -2123,6 +2123,13 @@
   version "5.11.8"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.8.tgz#e1ba16686276b75f501ebe4fd5b60ce600704e3c"
   integrity sha512-n/uJRIwZAaJaROaOA4VzycxDo27cusnrRzfycnAkAP5gBndwOJQ1CXjd1Y7hJe5eorj/ukixC7IZD+qCClMCMg==
+
+"@mui/icons-material@^5.11.9":
+  version "5.11.9"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.11.9.tgz#db26c106d0d977ae1fc0c2d20ba2e829a8174c05"
+  integrity sha512-SPANMk6K757Q1x48nCwPGdSNb8B71d+2hPMJ0V12VWerpSsbjZtvAPi5FAn13l2O5mwWkvI0Kne+0tCgnNxMNw==
+  dependencies:
+    "@babel/runtime" "^7.20.13"
 
 "@mui/material@^5.11.8":
   version "5.11.8"


### PR DESCRIPTION
## 📄 구현 내용 설명
아이디어에 따라 버튼에 옵션을 추가했습니다.
<img width="219" alt="Screenshot 2023-02-18 at 3 30 43 PM" src="https://user-images.githubusercontent.com/59170680/219845277-fbd92a5e-634a-4712-a0a0-c5580c5f3115.png">

### ⛱️ 주요 변경 사항

- `리드미를 위해 ![]() 꼴로 복사`, `링크만 복사`, `img 태그 형태로 복사` 세 옵션이 버튼에 추가됐습니다.
- dropdown icon을 위해 `mui/material-icons`를 설치했습니다.
- 헤더에 buy coffee 옵션은 우선 지워놨어요! 다음 기회에 ㅎ...

### 🙋 이 부분을 리뷰해주세요

- `ButtonOptions.tsx`는 대충 봐도 아주 끔찍한 코드에요.. 나중에 메인화면 성능 개선과 함께 반드시 리팩토링 할게요!

### 🤔 여기를 참고하면 도움이 돼요

-   [MUI material icons](https://mui.com/material-ui/material-icons/)
