### PR TITLE
결과 창에서 뒤로가기 클릭 시 메인으로 이동

### DIFF
--- a/src/pages/result/Result.tsx
+++ b/src/pages/result/Result.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { Button, Typography } from '@mui/material';
 import ButtonOptions from 'components/button-options/ButtonOptions';
 import { APP_NAME } from 'constants/constants';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 const Container = styled.div`
   position: absolute;
@@ -24,6 +24,11 @@ const Buttons = styled.div`
 
 const Result = () => {
   const { state } = useLocation();
+  const navigate = useNavigate();
+
+  window.addEventListener('popstate', () => {
+    navigate('/');
+  });
 
   return (
     <Container>


### PR DESCRIPTION
close #41 

## 📄 구현 내용 설명
결과 창에서 뒤로가기 클릭 시 로딩창이 아닌 메인으로 이동합니다.

### ⛱️ 주요 변경 사항

- 뒤로 가기 이벤트만 막으면 되는 일이라, window에 직접 이벤트 리스너를 붙였습니다. 만약에 다른 히스토리들을 다뤄야 한다면 수정해야 할 것 같아요.

### 🙋 이 부분을 리뷰해주세요

- 뒤로가기 이외의 이벤트를 고려해야 할까요?

### 🤔 여기를 참고하면 도움이 돼요

-   [history handling with react router v6](https://reactrouter.com/en/main/start/concepts#history-object)
