### PR TITLE
attach google analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "pretendard": "^1.3.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-ga": "^3.3.1",
     "react-router-dom": "^6.8.1",
     "react-scripts": "5.0.1",
     "simple-icons": "^8.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
 import { Box } from '@mui/material';
 import { ThemeProvider } from '@mui/system';
+import GoogleAnalyticsTracker from 'GoogleAnalyticsTracker';
 import { HashRouter } from 'react-router-dom';
 import Router from 'Router';
 import { theme } from 'styles/theme';
 
 function App() {
+  GoogleAnalyticsTracker();
+
   return (
     <ThemeProvider theme={theme}>
       <HashRouter>

--- a/src/GoogleAnalyticsTracker.tsx
+++ b/src/GoogleAnalyticsTracker.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import ReactGA from 'react-ga';
+import { useLocation } from 'react-router-dom';
+
+const GoogleAnalyticsTracker = () => {
+  const location = useLocation();
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (!window.location.href.includes('localhost')) {
+      ReactGA.initialize(process.env.REACT_APP_GOOGLE_ANALYTICS_TRACKING_ID as string);
+    }
+    setInitialized(true);
+  }, []);
+
+  useEffect(() => {
+    if (initialized) {
+      ReactGA.pageview(location.pathname + location.search);
+    }
+  }, [initialized, location]);
+};
+
+export default GoogleAnalyticsTracker;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8500,6 +8500,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-ga@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.1.tgz#d8e1f4e05ec55ed6ff944dcb14b99011dfaf9504"
+  integrity sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"


### PR DESCRIPTION
## 📄 구현 내용 설명
페이지 분석을 위해 google analytics를 심었습니다.

### ⛱️ 주요 변경 사항

- `GoogleAnalyticsTracker.tsx`에서 초기화 한 뒤 App,tsx에서 초기화했습니다.
- SPA로 동작하는 react에서 변화를 감지하려면 이렇게 작업해야 한다고 해요.
- `react-ga` 를 설치했습니다!

### 🙋 이 부분을 리뷰해주세요

- .env 업데이트 버전은 따로 전달드렸습니다!
- 여기까지 머지되면 .env 파일 업데이트 후 deploy 한번 부탁드려요 :)

### 🤔 여기를 참고하면 도움이 돼요

-   [react-ga로 리액트와 구글 애널리틱스  연결하기](https://fromnowwon.tistory.com/entry/react-ga-google-analytics)
-
