### PR TITLE
google analytics UA -> ga4로 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pretendard": "^1.3.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-ga": "^3.3.1",
+    "react-ga4": "^2.0.0",
     "react-router-dom": "^6.8.1",
     "react-scripts": "5.0.1",
     "simple-icons": "^8.5.0",

--- a/src/services/google-analytics/GoogleAnalyticsTracker.tsx
+++ b/src/services/google-analytics/GoogleAnalyticsTracker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import ReactGA from 'react-ga';
+import ReactGA from 'react-ga4';
 import { useLocation } from 'react-router-dom';
 
 const GoogleAnalyticsTracker = () => {
@@ -15,7 +15,7 @@ const GoogleAnalyticsTracker = () => {
 
   useEffect(() => {
     if (initialized) {
-      ReactGA.pageview(location.pathname + location.search);
+      ReactGA.send({ hitType: 'pageview', page: location.pathname + location.search });
     }
   }, [initialized, location]);
 };

--- a/src/services/google-analytics/GoogleAnalyticsTracker.tsx
+++ b/src/services/google-analytics/GoogleAnalyticsTracker.tsx
@@ -15,7 +15,7 @@ const GoogleAnalyticsTracker = () => {
 
   useEffect(() => {
     if (initialized) {
-      ReactGA.send({ hitType: 'pageview', page: location.pathname + location.search });
+      ReactGA.send({ hitType: 'pageview', page: location.pathname + location.hash });
     }
   }, [initialized, location]);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8500,10 +8500,10 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-ga@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.1.tgz#d8e1f4e05ec55ed6ff944dcb14b99011dfaf9504"
-  integrity sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==
+react-ga4@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.0.0.tgz#d125807cc30b087a6aa24401ec5f1f1c2d176fe9"
+  integrity sha512-WHi98hMunzh4ngRdNil8NN6Qly3ZZUkprhbgSqA+NFzovp8zqpYV3jcbKL9FnMdeBQHGhv8AVNCT2oFEE+EFXA==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
## 📄 구현 내용 설명
2023년 7월부로 기존에 설정했던 UA 방식이 지원이 중지된다고 해서, google analytics에서 권장하는 ga4로 변경했습니다.

### ⛱️ 주요 변경 사항

- `react-ga` -> `react-ga4`
-

### 🙋 이 부분을 리뷰해주세요

-
-

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
