### PR TITLE
replace scoll event with intersection observer

### DIFF
--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -46,23 +46,18 @@ const Home = () => {
   const [skills, setSkills] = useState<string[]>([]);
   const [buttonClicked, setButtonClicked] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const observerRef = useRef<HTMLDivElement>(null);
 
   const navigate = useNavigate();
 
-  const handleScroll = () => {
-    const { scrollTop } = document.documentElement;
-
-    if (scrollTop < 50) {
-      setScroll(false);
-    }
-    if (scrollTop >= 300) {
-      setScroll(true);
-    }
-  };
-
   useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+    const io = new IntersectionObserver(
+      (entries: IntersectionObserverEntry[]) => {
+        entries[0].isIntersecting ? setScroll(true) : setScroll(false);
+      },
+      { threshold: 0.1 },
+    );
+    io.observe(observerRef.current as HTMLElement);
   }, []);
 
   const changeSkillSet = (inputSkills: string[]) => {
@@ -114,6 +109,7 @@ const Home = () => {
       </div>
 
       <div
+        ref={observerRef}
         style={{
           width: '100%',
           height: '100vh',
@@ -179,16 +175,13 @@ const Home = () => {
               loading='lazy'
             />
           </Box>
-          <Box>
-            <Typography
-              variant='h4'
-              sx={{
-                animation: scroll ? `${fadeFromRight} 1s` : '',
-                display: scroll ? '' : 'none',
-              }}
-            >
-              Recognize in a glance
-            </Typography>
+          <Box
+            sx={{
+              animation: scroll ? `${fadeFromRight} 1s` : '',
+              display: scroll ? '' : 'none',
+            }}
+          >
+            <Typography variant='h4'>Recognize in a glance</Typography>
           </Box>
         </Container>
       </div>


### PR DESCRIPTION
close #21 

## 📄 구현 내용 설명
기존에 비효율적이던 스크롤 이벤트를 제거하고, intersection observer로 대체했습니다.

> ### Before
<img width="70%" src="https://user-images.githubusercontent.com/59170680/221368193-fbcbbc61-e9d3-4a0b-8c18-b96f1735a265.gif" alt="gif" />

> ### After
<img width="70%" src="https://user-images.githubusercontent.com/59170680/221368256-798aa45b-c09d-4b35-aba1-d9fc5b5bba70.gif" alt="gif" />


### ⛱️ 주요 변경 사항

- 기존에 비효율적이던 스크롤 이벤트를 제거하고, intersection observer로 대체했습니다.
- 개선점은 위 gif 파일에서 확인 가능합니다.

### 🤔 여기를 참고하면 도움이 돼요

-   [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
-
