### PR TITLE
mobile layout

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -58,7 +58,7 @@ const Header = () => {
             <SvgIcon viewBox='0 0 24 24'>
               <path d={Svg.github} />
             </SvgIcon>
-            <Typography color='primary.main'>source code</Typography>
+            <Typography color='primary.main'>visit github</Typography>
           </Box>
         </Link>
 

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Autocomplete, createFilterOptions, TextField } from '@mui/material';
+import { Autocomplete, createFilterOptions, TextField, useMediaQuery } from '@mui/material';
 import type { SimpleIcon } from 'simple-icons';
 
 import { makeIconInfoArray } from '../../utils/allIconInfo';
@@ -24,6 +24,7 @@ interface InputProps {
 }
 
 const Input = ({ handler }: InputProps) => {
+  const isMobile = useMediaQuery('(max-width: 900px)');
   const iconArr = makeIconInfoArray();
 
   const onStackChange = (e: React.SyntheticEvent, value: SimpleIcon[]) => {
@@ -36,7 +37,7 @@ const Input = ({ handler }: InputProps) => {
   };
 
   return (
-    <div style={{ width: '50%', zIndex: '50' }}>
+    <div style={{ width: isMobile ? '66%' : '50%', zIndex: '50' }}>
       <Autocomplete
         multiple
         id='tags-outlined'

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -46,23 +46,18 @@ const Home = () => {
   const [skills, setSkills] = useState<string[]>([]);
   const [buttonClicked, setButtonClicked] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const observerRef = useRef<HTMLDivElement>(null);
 
   const navigate = useNavigate();
 
-  const handleScroll = () => {
-    const { scrollTop } = document.documentElement;
-
-    if (scrollTop < 50) {
-      setScroll(false);
-    }
-    if (scrollTop >= 300) {
-      setScroll(true);
-    }
-  };
-
   useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+    const io = new IntersectionObserver(
+      (entries: IntersectionObserverEntry[]) => {
+        entries[0].isIntersecting ? setScroll(true) : setScroll(false);
+      },
+      { threshold: 0.1 },
+    );
+    io.observe(observerRef.current as HTMLElement);
   }, []);
 
   const changeSkillSet = (inputSkills: string[]) => {
@@ -114,6 +109,7 @@ const Home = () => {
       </div>
 
       <div
+        ref={observerRef}
         style={{
           width: '100%',
           height: '100vh',
@@ -179,16 +175,13 @@ const Home = () => {
               loading='lazy'
             />
           </Box>
-          <Box>
-            <Typography
-              variant='h4'
-              sx={{
-                animation: scroll ? `${fadeFromRight} 1s` : '',
-                display: scroll ? '' : 'none',
-              }}
-            >
-              Recognize in a glance
-            </Typography>
+          <Box
+            sx={{
+              animation: scroll ? `${fadeFromRight} 1s` : '',
+              display: scroll ? '' : 'none',
+            }}
+          >
+            <Typography variant='h4'>Recognize in a glance</Typography>
           </Box>
         </Container>
       </div>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Box, Button, Container, SvgIcon, Typography } from '@mui/material';
+import { Box, Button, Container, SvgIcon, Typography, useMediaQuery } from '@mui/material';
 import DraggableIcon from 'components/draggable-icon';
 import Header from 'components/header';
 import Input from 'components/input';
@@ -47,6 +47,7 @@ const Home = () => {
   const [buttonClicked, setButtonClicked] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const observerRef = useRef<HTMLDivElement>(null);
+  const isMobile = useMediaQuery('(max-width: 900px)');
 
   const navigate = useNavigate();
 
@@ -99,7 +100,7 @@ const Home = () => {
             zIndex: 50,
           }}
         >
-          Create Set
+          Create {isMobile ? '' : 'Set'}
         </Button>
 
         <DraggableIcon constraints={containerRef} icon={<ReactIcon />} bottom='10%' right='5%' />
@@ -120,6 +121,7 @@ const Home = () => {
             width: '100%',
             height: '50vh',
             display: 'flex',
+            flexDirection: isMobile ? 'column' : 'row',
             justifyContent: 'space-evenly',
             alignItems: 'center',
             gap: '10px',
@@ -138,13 +140,13 @@ const Home = () => {
           </Box>
           <Box
             sx={{
-              width: '550px',
+              width: isMobile ? '100%' : '550px',
               animation: scroll ? `${fadeFromRight} 1s` : '',
               display: scroll ? '' : 'none',
             }}
           >
             <img
-              width='550px'
+              width={isMobile ? '100%' : '550px'}
               src='https://user-images.githubusercontent.com/59170680/219634902-3ba561ac-cc65-4e1f-aff7-310fd100266e.gif'
               alt='choose stacks gif'
               loading='lazy'
@@ -156,6 +158,7 @@ const Home = () => {
             width: '100%',
             height: '40vh',
             display: 'flex',
+            flexDirection: isMobile ? 'column-reverse' : 'row',
             justifyContent: 'space-evenly',
             alignItems: 'center',
             gap: '10px',
@@ -163,13 +166,13 @@ const Home = () => {
         >
           <Box
             sx={{
-              width: '500px',
+              width: isMobile ? '100%' : '550px',
               animation: scroll ? `${fadeFromLeft} 1s` : '',
               display: scroll ? '' : 'none',
             }}
           >
             <img
-              width='500px'
+              width={isMobile ? '100%' : '550px'}
               src='https://user-images.githubusercontent.com/59170680/219640020-46b1972a-968d-495d-8f82-00bb90f03357.png'
               alt='create your own skill sets'
               loading='lazy'


### PR DESCRIPTION
close #49 

## 📄 구현 내용 설명
메인 화면에 모바일용 레이아웃을 적용했습니다.
레이아웃이 깨지는 900px을 기준으로 적용했습니다.

1. 
![image](https://user-images.githubusercontent.com/59170680/221370592-ccc0f160-f0f2-4fd5-be7c-bfd31e375cd4.png)

2.
![image](https://user-images.githubusercontent.com/59170680/221370662-16236bc8-f532-4da5-9194-c130a28b17c0.png)


### ⛱️ 주요 변경 사항

- MUI에서 제공하는 `useMediaQuery` 훅을 사용했습니다.
- 모바일에서는 버튼 텍스트가 'create set' 대신 'create'로 변경됩니다.
- 아래 페이지 설명에 가로로 배치되던 항목들이 세로로 배치됩니다.
- 상단의 깃허브 바로가기 텍스트를 visit github로 변경했습니다.

### 🙋 이 부분을 리뷰해주세요

- 
-

### 🤔 여기를 참고하면 도움이 돼요

- [useMediaQuery](https://mui.com/material-ui/react-use-media-query/)
- [show sketch on figma](https://www.figma.com/file/UXDS1f7WeLNruRrFa4kHly/stackticon?node-id=0%3A1&t=op4XOqqmkP9SR798-0)
