### PR TITLE
setting design system - color

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -22,23 +22,23 @@ export const theme = createTheme({
   },
   palette: {
     p: {
-      'p/1': '#ff00aa',
-      'p/2': 'linear-gradient(0deg, rgba(0, 102, 255, 0.8), rgba(0, 102, 255, 0.8)), #FFFFFF',
-      'p/3': 'linear-gradient(0deg, rgba(0, 102, 255, 0.6), rgba(0, 102, 255, 0.6)), #FFFFFF',
-      'p/4': 'linear-gradient(0deg, rgba(0, 102, 255, 0.4), rgba(0, 102, 255, 0.4)), #FFFFFF',
-      'p/5': 'linear-gradient(0deg, rgba(0, 102, 255, 0.2), rgba(0, 102, 255, 0.2)), #FFFFFF',
-      'p/6': 'linear-gradient(0deg, rgba(0, 102, 255, 0.1), rgba(0, 102, 255, 0.1)), #FFFFFF',
-      'p/7': 'linear-gradient(0deg, rgba(0, 102, 255, 0.06), rgba(0, 102, 255, 0.06)), #FFFFFF',
-      'p/8': 'linear-gradient(0deg, rgba(0, 102, 255, 0.04), rgba(0, 102, 255, 0.04)), #FFFFFF',
+      '1': '#0066ff',
+      '2': '#3385ff',
+      '3': '#66a3ff',
+      '4': '#99c2ff',
+      '5': '#cce0ff',
+      '6': '#e6f0ff',
+      '7': '#f0f6ff',
+      '8': '#f5f9ff',
     },
 
     cg: {
-      'cg/1': '#0A1320',
-      'cg/2': '#1A2339',
-      'cg/3': '#364261',
-      'cg/4': '#4B597D',
-      'cg/5': '#7886AA',
-      'cg/6': '#B3BACD',
+      '1': '#0A1320',
+      '2': '#1A2339',
+      '3': '#364261',
+      '4': '#4B597D',
+      '5': '#7886AA',
+      '6': '#B3BACD',
     },
 
     info: {
@@ -52,81 +52,67 @@ export const theme = createTheme({
 declare module '@mui/material/styles' {
   interface Palette {
     p: {
-      'p/1': string;
-      'p/2': string;
-      'p/3': string;
-      'p/4': string;
-      'p/5': string;
-      'p/6': string;
-      'p/7': string;
-      'p/8': string;
+      '1': string;
+      '2': string;
+      '3': string;
+      '4': string;
+      '5': string;
+      '6': string;
+      '7': string;
+      '8': string;
     };
 
     cg: {
-      'cg/1': string;
-      'cg/2': string;
-      'cg/3': string;
-      'cg/4': string;
-      'cg/5': string;
-      'cg/6': string;
+      '1': string;
+      '2': string;
+      '3': string;
+      '4': string;
+      '5': string;
+      '6': string;
     };
   }
 
   interface PaletteOptions {
     p: {
-      'p/1': string;
-      'p/2': string;
-      'p/3': string;
-      'p/4': string;
-      'p/5': string;
-      'p/6': string;
-      'p/7': string;
-      'p/8': string;
+      '1': string;
+      '2': string;
+      '3': string;
+      '4': string;
+      '5': string;
+      '6': string;
+      '7': string;
+      '8': string;
     };
 
     cg: {
-      'cg/1': string;
-      'cg/2': string;
-      'cg/3': string;
-      'cg/4': string;
-      'cg/5': string;
-      'cg/6': string;
+      '1': string;
+      '2': string;
+      '3': string;
+      '4': string;
+      '5': string;
+      '6': string;
     };
   }
 
   interface PaletteColor {
-    'p/1'?: string;
-    'p/2'?: string;
-    'p/3'?: string;
-    'p/4'?: string;
-    'p/5'?: string;
-    'p/6'?: string;
-    'p/7'?: string;
-    'p/8'?: string;
-
-    'cg/1'?: string;
-    'cg/2'?: string;
-    'cg/3'?: string;
-    'cg/4'?: string;
-    'cg/5'?: string;
-    'cg/6'?: string;
+    '1'?: string;
+    '2'?: string;
+    '3'?: string;
+    '4'?: string;
+    '5'?: string;
+    '6'?: string;
+    '7'?: string;
+    '8'?: string;
   }
 
   interface SimplePaletteColorOptions {
-    'p/1'?: string;
-    'p/2'?: string;
-    'p/3'?: string;
-    'p/4'?: string;
-    'p/5'?: string;
-    'p/6'?: string;
-    'p/7'?: string;
-    'p/8'?: string;
-
-    'cg/1'?: string;
-    'cg/2'?: string;
-    'cg/3'?: string;
-    'cg/4'?: string;
-    'cg/5'?: string;
-    'cg/6'?: string;
+    '1'?: string;
+    '2'?: string;
+    '3'?: string;
+    '4'?: string;
+    '5'?: string;
+    '6'?: string;
+    '7'?: string;
+    '8'?: string;
   }
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -21,33 +21,112 @@ export const theme = createTheme({
     ].join(','),
   },
   palette: {
-    primary: {
-      light: '#FFFBF2',
-      main: '#FFF8EA',
-      dark: '#DBC9AB',
-    },
-    success: {
-      light: '#58CE5C',
-      main: '#58CE5C',
-      dark: '#2C9442',
-    },
-    info: {
-      light: '#70C2FD',
-      main: '#1383F9',
-      dark: '#094BB3',
-    },
-    warning: {
-      light: '#F1F783',
-      main: '#D9E532',
-      dark: '#99A419',
-    },
-    common: {
-      black: '#191919',
-      white: '#F5F5F5',
+    p: {
+      'p/1': '#ff00aa',
+      'p/2': 'linear-gradient(0deg, rgba(0, 102, 255, 0.8), rgba(0, 102, 255, 0.8)), #FFFFFF',
+      'p/3': 'linear-gradient(0deg, rgba(0, 102, 255, 0.6), rgba(0, 102, 255, 0.6)), #FFFFFF',
+      'p/4': 'linear-gradient(0deg, rgba(0, 102, 255, 0.4), rgba(0, 102, 255, 0.4)), #FFFFFF',
+      'p/5': 'linear-gradient(0deg, rgba(0, 102, 255, 0.2), rgba(0, 102, 255, 0.2)), #FFFFFF',
+      'p/6': 'linear-gradient(0deg, rgba(0, 102, 255, 0.1), rgba(0, 102, 255, 0.1)), #FFFFFF',
+      'p/7': 'linear-gradient(0deg, rgba(0, 102, 255, 0.06), rgba(0, 102, 255, 0.06)), #FFFFFF',
+      'p/8': 'linear-gradient(0deg, rgba(0, 102, 255, 0.04), rgba(0, 102, 255, 0.04)), #FFFFFF',
     },
 
-    background: {
-      default: '#FFFBF2',
+    cg: {
+      'cg/1': '#0A1320',
+      'cg/2': '#1A2339',
+      'cg/3': '#364261',
+      'cg/4': '#4B597D',
+      'cg/5': '#7886AA',
+      'cg/6': '#B3BACD',
+    },
+
+    info: {
+      light: '#F9F9F9',
+      main: '#8A8A8A',
+      dark: '#444A52',
     },
   },
 });
+
+declare module '@mui/material/styles' {
+  interface Palette {
+    p: {
+      'p/1': string;
+      'p/2': string;
+      'p/3': string;
+      'p/4': string;
+      'p/5': string;
+      'p/6': string;
+      'p/7': string;
+      'p/8': string;
+    };
+
+    cg: {
+      'cg/1': string;
+      'cg/2': string;
+      'cg/3': string;
+      'cg/4': string;
+      'cg/5': string;
+      'cg/6': string;
+    };
+  }
+
+  interface PaletteOptions {
+    p: {
+      'p/1': string;
+      'p/2': string;
+      'p/3': string;
+      'p/4': string;
+      'p/5': string;
+      'p/6': string;
+      'p/7': string;
+      'p/8': string;
+    };
+
+    cg: {
+      'cg/1': string;
+      'cg/2': string;
+      'cg/3': string;
+      'cg/4': string;
+      'cg/5': string;
+      'cg/6': string;
+    };
+  }
+
+  interface PaletteColor {
+    'p/1'?: string;
+    'p/2'?: string;
+    'p/3'?: string;
+    'p/4'?: string;
+    'p/5'?: string;
+    'p/6'?: string;
+    'p/7'?: string;
+    'p/8'?: string;
+
+    'cg/1'?: string;
+    'cg/2'?: string;
+    'cg/3'?: string;
+    'cg/4'?: string;
+    'cg/5'?: string;
+    'cg/6'?: string;
+  }
+
+  interface SimplePaletteColorOptions {
+    'p/1'?: string;
+    'p/2'?: string;
+    'p/3'?: string;
+    'p/4'?: string;
+    'p/5'?: string;
+    'p/6'?: string;
+    'p/7'?: string;
+    'p/8'?: string;
+
+    'cg/1'?: string;
+    'cg/2'?: string;
+    'cg/3'?: string;
+    'cg/4'?: string;
+    'cg/5'?: string;
+    'cg/6'?: string;
+  }
+}


### PR DESCRIPTION
related to #65 

## 📄 What I've done
setting design systems with custom colors

### ⛱️ Major Changes

- extended `Palette` interface to use custom names
- set color names
> usage

```
p/1 (in figma) -> p.1 (in code)
cg/1 (in figma) -> cg.1 (in code) 
```

> colors which don't have names
![image](https://user-images.githubusercontent.com/59170680/224694695-bdeeb4ff-30d8-4854-870b-d356365ffd21.png)

```
info: {
  light: '#F9F9F9',
  main: '#8A8A8A',
  dark: '#444A52',
},
```


### 🙋 Review Points

- I wanted to seperate types for Palette into file like `style.d.ts` but didn't get how to do it 😥
- And also want to remove things that repeat like:
```
{
  1: '..', 
  2: '..', 
  3: '..',
}
```

I'm thinking about making it into type alias. Tell me if there is other better ways to make it clean!

### 🤔 References

- [custom theming in MUI](https://mui.com/material-ui/customization/theming/#custom-variables)
-
