### PR TITLE
copy right after select option

### DIFF
--- a/src/components/button-options/ButtonOptions.tsx
+++ b/src/components/button-options/ButtonOptions.tsx
@@ -40,6 +40,7 @@ const ButtonOptions = (state: any) => {
   const clickCopyOption = (e: React.MouseEvent<HTMLLIElement, MouseEvent>, index: number) => {
     setSelectedOption(index);
     setOpenOptions(false);
+    clickCopyUrl();
   };
 
   const handleToggle = () => {


### PR DESCRIPTION
close #67

## 📄 What I've done
copy in clipboard right after select option in result page


### ⛱️ Major Changes

- called `clickCopyUrl` function when click option. Therefore, result is copied when select option. After first copy, user can copy again everytime click copy button.

### 🙋 Review Points

-
-

