### PR TITLE
responsive layout on every page

### DIFF
--- a/src/components/BackgroundCircle/BackgroundCircle.tsx
+++ b/src/components/BackgroundCircle/BackgroundCircle.tsx
@@ -6,6 +6,7 @@ const BackgroundCircle = () => (
     height='36.6875rem'
     bgcolor='p.8'
     borderRadius='50%'
+    zIndex='2'
     sx={{
       filter: 'blur(25px)',
     }}

--- a/src/components/button-options/ButtonOptions.tsx
+++ b/src/components/button-options/ButtonOptions.tsx
@@ -60,11 +60,12 @@ const ButtonOptions = (state: any) => {
       <ButtonGroup
         ref={buttonRef}
         aria-label='button with options'
-        style={{ marginRight: '10px' }}
         variant='contained'
         sx={{
+          width: 'fit-content',
           backgroundColor: 'p.1',
           borderRadius: '12px',
+          marginRight: '10px',
         }}
       >
         <Button

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { Box, Link, Stack, SvgIcon, Typography } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import LogoWithBackground from 'assets/icons/logoWithBackground';
 import { APP_NAME, GITHUB_LINK } from 'constants/constants';
 import { Svg } from 'constants/Svg';
@@ -12,7 +13,7 @@ const Container = styled.header`
   width: 100%;
   height: 86px;
   background-color: #ffffff;
-  padding: 0px 80px;
+  padding: 0px 4.2vw;
 
   position: fixed;
 
@@ -25,7 +26,7 @@ const RouterLink = styled(RLink)`
   display: flex;
   align-items: center;
 
-  gap: 9px;
+  gap: 0.5625rem;
 `;
 
 const GithubLink = styled(Link)`
@@ -44,6 +45,8 @@ const GithubLink = styled(Link)`
 `;
 
 const Header = () => {
+  const isMobile = useMediaQuery('(max-width: 740px)');
+
   return (
     <Container>
       <RouterLink to='/'>
@@ -52,7 +55,7 @@ const Header = () => {
           variant='h4'
           color='#323443'
           fontWeight='bold'
-          fontSize='28px'
+          fontSize='1.75rem'
           sx={{
             cursor: 'pointer',
           }}
@@ -62,7 +65,14 @@ const Header = () => {
       </RouterLink>
 
       <Stack direction='row' spacing={2} marginLeft='auto'>
-        <GithubLink href={GITHUB_LINK} target='_blank' rel='noreferrer'>
+        <GithubLink
+          href={GITHUB_LINK}
+          target='_blank'
+          rel='noreferrer'
+          sx={{
+            scale: isMobile ? '0.7' : '1',
+          }}
+        >
           <Box
             component='div'
             sx={{

--- a/src/components/stacks/Stacks.tsx
+++ b/src/components/stacks/Stacks.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material';
 import Stack from 'components/stack/Stack';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { BgColorOption } from 'types/backgroundColors';
 
 interface StacksProps extends BgColorOption {

--- a/src/pages/background-colors/BackgroundColors.tsx
+++ b/src/pages/background-colors/BackgroundColors.tsx
@@ -94,7 +94,13 @@ const BackgroundColors = () => {
     >
       <Header />
       <CustomContainer>
-        <Typography textAlign='center' p={5} fontWeight='800' fontSize='4.375rem' color='cg.1'>
+        <Typography
+          textAlign='center'
+          p={5}
+          fontWeight='800'
+          fontSize={isMobile ? '2rem' : '4.375rem'}
+          color='cg.1'
+        >
           Choose Color
         </Typography>
 

--- a/src/pages/background-colors/BackgroundColors.tsx
+++ b/src/pages/background-colors/BackgroundColors.tsx
@@ -16,6 +16,10 @@ const CustomContainer = styled.div`
   justify-content: center;
 
   padding-top: 13.0625rem;
+
+  position: relative;
+
+  z-index: 5;
 `;
 
 const StackContainer = styledMUI(Box)(({ theme }) => ({
@@ -89,7 +93,7 @@ const BackgroundColors = () => {
     >
       <Header />
       <CustomContainer>
-        <Typography textAlign='center' p={5} fontWeight='800' fontSize='70px' color='cg.1'>
+        <Typography textAlign='center' p={5} fontWeight='800' fontSize='4.375rem' color='cg.1'>
           Choose Color
         </Typography>
 

--- a/src/pages/background-colors/BackgroundColors.tsx
+++ b/src/pages/background-colors/BackgroundColors.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Box, Container, styled as styledMUI, Typography } from '@mui/material';
+import { Box, Container, styled as styledMUI, Typography, useMediaQuery } from '@mui/material';
 import BackgroundCircle from 'components/BackgroundCircle';
 import Header from 'components/header';
 import Stacks from 'components/stacks';
@@ -72,6 +72,7 @@ const BackgroundColors = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
   const targetRef = useRef<HTMLDivElement>(null);
+  const isMobile = useMediaQuery('(max-width: 740px)');
 
   const submitSkills = (color: BgColorOption['color']) => {
     const bgColor = color;
@@ -112,6 +113,10 @@ const BackgroundColors = () => {
             onClick={() => submitSkills('black')}
             onMouseEnter={() => setHideBlack(true)}
             onMouseLeave={() => setHideBlack(false)}
+            sx={{
+              scale: isMobile ? '0.5' : '1',
+              transform: isMobile ? 'translateY(-10rem)' : '0',
+            }}
           >
             <Stacks ref={targetRef} selecteds={state} color='black' />
             {hideBlack && <Hider />}
@@ -121,6 +126,10 @@ const BackgroundColors = () => {
             onClick={() => submitSkills('white')}
             onMouseEnter={() => setHideWhite(true)}
             onMouseLeave={() => setHideWhite(false)}
+            sx={{
+              scale: isMobile ? '0.5' : '1',
+              transform: isMobile ? 'translateY(-30rem)' : '0',
+            }}
           >
             <Stacks ref={targetRef} selecteds={state} color='white' />
             {hideWhite && <Hider />}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -79,11 +79,20 @@ const Home = () => {
           alignItems: 'center',
           position: 'relative',
           paddingTop: '150px',
-          gap: '61px',
+          gap: isMobile ? '10px' : '61px',
           backgroundColor: '#f9f9f9',
         }}
       >
-        <Box display='flex' flexDirection='column' justifyContent='center' alignItems='center'>
+        <Box
+          display='flex'
+          flexDirection='column'
+          justifyContent='center'
+          alignItems='center'
+          zIndex='3'
+          sx={{
+            scale: isMobile ? '0.7' : '1',
+          }}
+        >
           <img
             src={require('../../assets/images/landing-image.png')}
             alt='landing-image'
@@ -111,6 +120,7 @@ const Home = () => {
             alignItems: 'center',
             gap: '20px',
             width: '100%',
+            scale: isMobile ? '0.7' : '1',
           }}
         >
           <Input handler={changeSkillSet} />

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -120,6 +120,7 @@ const Home = () => {
             alignItems: 'center',
             gap: '20px',
             width: '100%',
+            zIndex: '5',
             scale: isMobile ? '0.7' : '1',
           }}
         >

--- a/src/pages/result/Result.tsx
+++ b/src/pages/result/Result.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { Box, Button } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import BackgroundCircle from 'components/BackgroundCircle';
 import ButtonOptions from 'components/button-options/ButtonOptions';
 import Header from 'components/header';
@@ -11,6 +12,7 @@ const Container = styled.div`
   left: 50%;
   transform: translate(-50%, -70%);
   text-align: center;
+  z-index: 5;
 `;
 
 const Img = styled.img`
@@ -21,6 +23,7 @@ const Img = styled.img`
 
 const Buttons = styled.div`
   display: flex;
+  align-items: center;
   justify-content: center;
 
   gap: 3.625rem;
@@ -29,6 +32,7 @@ const Buttons = styled.div`
 const Result = () => {
   const { state } = useLocation();
   const navigate = useNavigate();
+  const isMobile = useMediaQuery('(max-width: 740px)');
 
   window.addEventListener('popstate', () => {
     navigate('/');
@@ -40,6 +44,7 @@ const Result = () => {
         width: '100vw',
         height: '100vh',
         backgroundColor: '#f9f9f9',
+        position: 'relative',
       }}
     >
       <Header />
@@ -50,8 +55,9 @@ const Result = () => {
           width='312px'
           height='52px'
           style={{
-            marginTop: '250px',
+            marginTop: isMobile ? '150px' : '250px',
             transform: 'translateX(-5px)',
+            scale: isMobile ? '0.7' : '1',
           }}
         />
         <div
@@ -62,7 +68,11 @@ const Result = () => {
         >
           <Img src={state} alt='stackticon result' />
         </div>
-        <Buttons>
+        <Buttons
+          style={{
+            flexDirection: isMobile ? 'column' : 'row',
+          }}
+        >
           <ButtonOptions url={state} />
           <Link to='/' style={{ textDecoration: 'none' }}>
             <Button


### PR DESCRIPTION
## 📄 What I've done
responsive layout on every page

### ⛱️ Major Changes

- reponsive pages : main, background select, result page
- here's are screenshots:

> main

![image](https://user-images.githubusercontent.com/59170680/226965240-b05f3659-8820-4ff1-abc6-ef62e272db8b.png)

> background select

![image](https://user-images.githubusercontent.com/59170680/226959981-7a37b0b1-e159-47f3-9f72-f20a8532e56f.png)

> result

![image](https://user-images.githubusercontent.com/59170680/226963518-5b7cfc5d-70b7-42c6-a55e-041933cf109c.png)


### 🙋 Review Points

- I used `media query` for making layout responsive. Please share your way about making responsive layouts
- Please deploy after merge 🙃

### 🤔 References

- [useMediaQuery](https://mui.com/material-ui/react-use-media-query/)
