### PR TITLE
Refactor: Use useEffect hook for optimization in Input

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { Autocomplete, createFilterOptions, TextField, useMediaQuery } from '@mui/material';
+import { useEffect, useState } from 'react';
 import type { SimpleIcon } from 'simple-icons';
 
 import { makeIconInfoArray } from '../../utils/allIconInfo';
@@ -25,7 +26,7 @@ interface InputProps {
 
 const Input = ({ handler }: InputProps) => {
   const isMobile = useMediaQuery('(max-width: 900px)');
-  const iconArr = makeIconInfoArray();
+  const [iconArr, setIconarr] = useState<[] | SimpleIcon[]>([]);
 
   const onStackChange = (e: React.SyntheticEvent, value: SimpleIcon[]) => {
     handler(
@@ -35,6 +36,10 @@ const Input = ({ handler }: InputProps) => {
       ),
     );
   };
+
+  useEffect(() => {
+    setIconarr(makeIconInfoArray);
+  }, []);
 
   return (
     <div style={{ width: isMobile ? '66%' : '50%', zIndex: '50' }}>


### PR DESCRIPTION
## 📄 What I've done
To solve the performance problem that continued rendering when MainPage was loaded, iconArr was loaded only at the first rendering using useEffect.

### ⛱️ Major Changes
- Add useEffect on Input.tsx

### 🙋 Review Points
- I did a performance measurement, but I'm not sure if the useEffect performance measurement has any effect. I would appreciate it if you could let me know if it is possible to measure the exact performance 🐤

### 🚀 Before & After

Before 1
![useEffect안쓸때](https://user-images.githubusercontent.com/87933367/228564295-c7b69e10-1c9e-4df5-b3a7-0b3711051154.PNG)

After 1
![useEffect쓸때](https://user-images.githubusercontent.com/87933367/228564354-731934d4-382f-45f3-a843-fb68b09cee9e.PNG)


Before 2
![useEffect안쓸때2](https://user-images.githubusercontent.com/87933367/228564415-9efc5511-6e7e-479b-8c9f-e8b1979747a9.PNG)


After 2
![useEffect쓸때2](https://user-images.githubusercontent.com/87933367/228564444-502aa72a-9999-4758-b83b-6efb81a36170.PNG)
