### PR TITLE
fix: button option is expanded when button clicked

### DIFF
--- a/src/components/button-options/ButtonOptions.tsx
+++ b/src/components/button-options/ButtonOptions.tsx
@@ -87,17 +87,19 @@ const ButtonOptions = ({ state }: { state: LocationState }) => {
         </Button>
       </ButtonGroup>
 
-      <OptionListContainer buttonRef={buttonRef.current} handleClose={handleClose}>
-        {copyOptions.map((option, idx) => (
-          <MenuItem
-            key={option + idx}
-            selected={idx === selectedOption}
-            onClick={(e) => clickCopyOption(e, idx)}
-          >
-            {option}
-          </MenuItem>
-        ))}
-      </OptionListContainer>
+      {openOptions && (
+        <OptionListContainer buttonRef={buttonRef.current} handleClose={handleClose}>
+          {copyOptions.map((option, idx) => (
+            <MenuItem
+              key={option + idx}
+              selected={idx === selectedOption}
+              onClick={(e) => clickCopyOption(e, idx)}
+            >
+              {option}
+            </MenuItem>
+          ))}
+        </OptionListContainer>
+      )}
     </Fragment>
   );
 };


### PR DESCRIPTION
close #107 

## 📄 What I've done
show button options when arrow is clicked
