### PR TITLE
fix: husky Checking errors when build project

### DIFF
--- a/.husky/common.sh
+++ b/.husky/common.sh
@@ -1,0 +1,8 @@
+command_exists () {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Workaround for Windows 10, Git Bash and Yarn
+if command_exists winpty && test -t 1; then
+  exec < /dev/tty
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+. "$(dirname -- "$0")/common.sh"
+
 protected_branch='main'
 policy='[Policy] DO NOT PUSH it directly to '$protected_branch' branch'
 


### PR DESCRIPTION
## 📄 What I've done
- Create .husky/common.sh
- Source it in in places where Yarn is used to run commands:

### ⛱️ Major Changes
- Create .husky/common.sh
- Add `. "$(dirname -- "$0")/common.sh"` in pre-push



### 🤔 References
- [[husky]yarn on windows](https://typicode.github.io/husky/troubleshooting.html#yarn-on-windows)
