### PR TITLE
new feature: drag and drop to change stack order

### DIFF
--- a/src/components/drag-container/DragContainer.tsx
+++ b/src/components/drag-container/DragContainer.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import type { SimpleIcon } from 'simple-icons';
+
+import { DraggableChip } from './DraggableChip';
+
+interface DragContainerProps {
+  array: SimpleIcon[];
+  updateArray: (s: SimpleIcon[]) => void;
+}
+
+export const DragContainer = ({ array, updateArray }: DragContainerProps) => {
+  const [selected, setSelected] = useState<SimpleIcon>();
+
+  const reorderArray = (index: number) => {
+    const filteredArray = array.filter((el) => el !== selected);
+
+    const prev = filteredArray.slice(0, index);
+    const next = filteredArray.slice(index, filteredArray.length);
+
+    if (prev && next && selected) {
+      updateArray([...prev, selected, ...next]);
+    }
+  };
+
+  const deleteItem = (index: number) => {
+    const deleted = array.filter((el, idx) => idx !== index);
+    updateArray(deleted);
+  };
+
+  const mouseUp = (index: number) => {
+    reorderArray(index);
+  };
+
+  const mouseDown = (index: number) => {
+    setSelected(array[index]);
+  };
+
+  return (
+    <>
+      {array.map((stack, index) => (
+        <DraggableChip
+          key={stack.path}
+          stack={stack}
+          mouseUp={() => mouseUp(index)}
+          mouseDown={() => mouseDown(index)}
+          deleteItem={() => deleteItem(index)}
+        />
+      ))}
+    </>
+  );
+};

--- a/src/components/drag-container/DragContainer.tsx
+++ b/src/components/drag-container/DragContainer.tsx
@@ -24,7 +24,7 @@ export const DragContainer = ({ array, updateArray }: DragContainerProps) => {
 
   const deleteItem = (index: number) => {
     const deleted = array.filter((el, idx) => idx !== index);
-    updateArray(deleted);
+    updateArray([...deleted]);
   };
 
   const mouseUp = (index: number) => {

--- a/src/components/drag-container/DraggableChip.tsx
+++ b/src/components/drag-container/DraggableChip.tsx
@@ -1,4 +1,4 @@
-import { DeleteTag } from 'constants/icons';
+import { Chip } from '@mui/material';
 import type { SimpleIcon } from 'simple-icons';
 
 interface DraggableChipProps {
@@ -10,28 +10,16 @@ interface DraggableChipProps {
 
 export const DraggableChip = ({ stack, mouseUp, mouseDown, deleteItem }: DraggableChipProps) => {
   return (
-    <div
-      style={{
-        margin: '0 5px',
-        padding: '3px 8px',
-        paddingLeft: '14px',
-        cursor: 'pointer',
-        backgroundColor: '#e6f0ff',
-        fontSize: '14px',
-        border: '1px solid #99c2ff',
-        borderRadius: '20px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        gap: '10px',
-      }}
-      onMouseUp={mouseUp}
-      onMouseDown={mouseDown}
-    >
-      {stack.title}
-      <div onClick={deleteItem}>
-        <DeleteTag />
-      </div>
+    <div onMouseDown={mouseDown} onMouseUp={mouseUp}>
+      <Chip
+        label={stack.title}
+        onDelete={deleteItem}
+        sx={{
+          bgcolor: '#e6f0ff',
+          border: '1px solid #99c2ff',
+          margin: '0 3px',
+        }}
+      />
     </div>
   );
 };

--- a/src/components/drag-container/DraggableChip.tsx
+++ b/src/components/drag-container/DraggableChip.tsx
@@ -1,0 +1,37 @@
+import { DeleteTag } from 'constants/icons';
+import type { SimpleIcon } from 'simple-icons';
+
+interface DraggableChipProps {
+  stack: SimpleIcon;
+  mouseUp: () => void;
+  mouseDown: () => void;
+  deleteItem: () => void;
+}
+
+export const DraggableChip = ({ stack, mouseUp, mouseDown, deleteItem }: DraggableChipProps) => {
+  return (
+    <div
+      style={{
+        margin: '0 5px',
+        padding: '3px 8px',
+        paddingLeft: '14px',
+        cursor: 'pointer',
+        backgroundColor: '#e6f0ff',
+        fontSize: '14px',
+        border: '1px solid #99c2ff',
+        borderRadius: '20px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '10px',
+      }}
+      onMouseUp={mouseUp}
+      onMouseDown={mouseDown}
+    >
+      {stack.title}
+      <div onClick={deleteItem}>
+        <DeleteTag />
+      </div>
+    </div>
+  );
+};

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,5 +1,12 @@
 import styled from '@emotion/styled';
-import { Autocomplete, createFilterOptions, TextField, useMediaQuery } from '@mui/material';
+import {
+  Autocomplete,
+  createFilterOptions,
+  ListItem,
+  TextField,
+  useMediaQuery,
+} from '@mui/material';
+import { DragContainer } from 'components/drag-container/DragContainer';
 import { useEffect, useState } from 'react';
 import type { SimpleIcon } from 'simple-icons';
 
@@ -31,7 +38,7 @@ const Input = ({ stacks, handler }: InputProps) => {
 
   const [inputStacks, setInputStacks] = useState<SimpleIcon[]>([]);
 
-  const onStackChange = (e: React.SyntheticEvent, value: SimpleIcon[]) => {
+  const onStackChange = (value: SimpleIcon[]) => {
     handler(
       value.map(
         (el: SimpleIcon) =>
@@ -49,31 +56,34 @@ const Input = ({ stacks, handler }: InputProps) => {
     setInputStacks(ret);
   }, [stacks]);
 
+  const changeStackOrder = (stacks: SimpleIcon[]) => {
+    setInputStacks(stacks);
+  };
+
   return (
     <div style={{ width: isMobile ? '66%' : '50%', zIndex: '50' }}>
       <Autocomplete
         multiple
         id='tags-outlined'
         options={iconArr}
-        renderOption={(props, option) => {
-          return (
-            <li {...props} key={option.path}>
-              <DropdownSvg
-                dangerouslySetInnerHTML={{ __html: option.svg }}
-                hex={'#' + option.hex}
-              ></DropdownSvg>
-              {option.title}
-            </li>
-          );
-        }}
+        renderOption={(props, option) => (
+          <ListItem {...props} key={option.path}>
+            <DropdownSvg
+              dangerouslySetInnerHTML={{ __html: option.svg }}
+              hex={'#' + option.hex}
+            ></DropdownSvg>
+            {option.title}
+          </ListItem>
+        )}
         getOptionLabel={(option) => option.title}
         value={inputStacks}
         isOptionEqualToValue={(option, value) => {
           return option.slug === value.slug;
         }}
-        onChange={(e, value) => onStackChange(e, value)}
+        onChange={(e, value) => onStackChange(value)}
         filterSelectedOptions
         renderInput={(params) => <TextField {...params} placeholder='Choose Your Stacks!' />}
+        renderTags={(stacks) => <DragContainer array={stacks} updateArray={changeStackOrder} />}
         filterOptions={createFilterOptions({
           limit: 100,
         })}

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -58,6 +58,7 @@ const Input = ({ stacks, handler }: InputProps) => {
 
   const changeStackOrder = (stacks: SimpleIcon[]) => {
     setInputStacks(stacks);
+    onStackChange(stacks);
   };
 
   return (

--- a/src/constants/icons.tsx
+++ b/src/constants/icons.tsx
@@ -1,5 +1,4 @@
-import CloseIcon from '@mui/icons-material/Close';
-import { Box, SvgIcon } from '@mui/material';
+import { SvgIcon } from '@mui/material';
 
 import { Svg } from './svgs';
 
@@ -38,29 +37,4 @@ export const BetaBadge = () => (
       fill='white'
     />
   </SvgIcon>
-);
-
-export const DeleteTag = () => (
-  <Box
-    width={'18px'}
-    height={'18px'}
-    bgcolor={'#99c2ff'}
-    border={'none'}
-    borderRadius={'50%'}
-    display={'flex'}
-    alignItems={'center'}
-    justifyContent={'center'}
-    sx={{
-      cursor: 'pointer',
-    }}
-  >
-    <CloseIcon
-      sx={{
-        width: '90%',
-        height: '90%',
-        border: '5px',
-        color: 'white',
-      }}
-    />
-  </Box>
 );

--- a/src/constants/icons.tsx
+++ b/src/constants/icons.tsx
@@ -1,4 +1,5 @@
-import { SvgIcon } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { Box, SvgIcon } from '@mui/material';
 
 import { Svg } from './svgs';
 
@@ -37,4 +38,29 @@ export const BetaBadge = () => (
       fill='white'
     />
   </SvgIcon>
+);
+
+export const DeleteTag = () => (
+  <Box
+    width={'18px'}
+    height={'18px'}
+    bgcolor={'#99c2ff'}
+    border={'none'}
+    borderRadius={'50%'}
+    display={'flex'}
+    alignItems={'center'}
+    justifyContent={'center'}
+    sx={{
+      cursor: 'pointer',
+    }}
+  >
+    <CloseIcon
+      sx={{
+        width: '90%',
+        height: '90%',
+        border: '5px',
+        color: 'white',
+      }}
+    />
+  </Box>
 );


### PR DESCRIPTION
## 📄 What I've done
drag-and-drop chips to change order

![draganddrop](https://github.com/msdio/stackticon/assets/59170680/f314d8d5-8439-46bc-bd3e-8c21d7d21a7e)

### ⛱️ Major Changes

- create components : `DragContainer`, `DraggableItem`
- add `renderTags` option in AutoComplete to show stacks has changed
- used mouseUp, mouseDown events with drag-and-drop
- change li into `ListItem` in MUI

### 🤔 References

- [renderTags options on MUI Autocomplete](https://mui.com/material-ui/api/autocomplete/#props)

### FYI
create release and update app version after merge this pull request
