### PR TITLE
handle when there is only dev-dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skill-set-generator",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "skill-set-generator",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "MIT",
       "dependencies": {
         "@testing-library/jest-dom": "^5.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stackticon",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "private": true,
   "description": "make skill sets image for readme",
   "main": "index.js",

--- a/src/utils/extractStacks.ts
+++ b/src/utils/extractStacks.ts
@@ -2,9 +2,12 @@ import { DEPENDENCY, DEV_DEPENDENCY } from 'constants/constants';
 import type { PackageJSONType } from 'types/packageJson';
 
 export const extractDependencies = (packageObj: PackageJSONType) => {
-  const dependencies = Object.keys(packageObj[DEPENDENCY]);
-
+  let dependencies: string[] = [];
   let devDependencies: string[] = [];
+
+  if (DEPENDENCY in packageObj) {
+    dependencies = Object.keys(packageObj[DEPENDENCY]);
+  }
   if (DEV_DEPENDENCY in packageObj) {
     devDependencies = Object.keys(packageObj[DEV_DEPENDENCY]);
   }


### PR DESCRIPTION
## 📄 What I've done

there would be three cases in package.json.

1. when there is only dependencies
2. when there is only devDependencies
3. both dependencies and devDependencies are exist

it had been considered case 2 and 3, but I added for case 1 in case there is only devDependencies.

### ⛱️ Major Changes

- added condition in `[src/utils/extractStacks.ts](https://github.com/msdio/stackticon/compare/fix/read-repository?expand=1#diff-6dbc04d8d9a78036ac5f90889a8882e55696b33b5ac8af0054832d46c736f905)`

### 🙋 Review Points

- project that have only devDependencies, is it possible?
