### PR TITLE
Fix: get package.json when the default branch is master

### DIFF
--- a/src/utils/resultUrl.ts
+++ b/src/utils/resultUrl.ts
@@ -19,7 +19,7 @@ export const getPackageJSONFromRepository = (url: string) => {
   }
 
   if (!repositoryLocation.includes('/main')) {
-    repositoryLocation = repositoryLocation.concat('/main');
+    repositoryLocation = repositoryLocation.concat('/master');
   }
 
   return PREFIX + repositoryLocation + SUFFIX;

--- a/src/utils/resultUrl.ts
+++ b/src/utils/resultUrl.ts
@@ -19,7 +19,7 @@ export const getPackageJSONFromRepository = (url: string) => {
   }
 
   if (!repositoryLocation.includes('/main')) {
-    repositoryLocation = repositoryLocation.concat('/master');
+    repositoryLocation = repositoryLocation.concat('/HEAD');
   }
 
   return PREFIX + repositoryLocation + SUFFIX;

--- a/src/utils/resultUrl.ts
+++ b/src/utils/resultUrl.ts
@@ -18,9 +18,7 @@ export const getPackageJSONFromRepository = (url: string) => {
     repositoryLocation = repositoryLocation.slice(0, -1);
   }
 
-  if (!repositoryLocation.includes('/main')) {
-    repositoryLocation = repositoryLocation.concat('/HEAD');
-  }
+  repositoryLocation = repositoryLocation.concat('/HEAD');
 
   return PREFIX + repositoryLocation + SUFFIX;
 };


### PR DESCRIPTION
## 📄 What I've done
You can import package.json even when the repository's default branch is `master`.

### 🙋 Review Points
I have tested some GitHub repository links and found that I couldn't access when default branch is master. (Whether the link is a public repository or an Organization repository)

The issues are as follows:

For public repository links:
   - Only if the default branch is `main`,  we can get the package.json.
   - It is not possible for the `master` branch.

### 🤔 
[Discussion link I posted](https://github.com/msdio/stackticon/discussions/125#discussion-5410299)
