### PR TITLE
Fix: URL Handling and Branch Detection to get package.json

### DIFF
--- a/src/utils/resultUrl.ts
+++ b/src/utils/resultUrl.ts
@@ -19,7 +19,7 @@ export const getPackageJSONFromRepository = (url: string) => {
   }
 
   if (!repositoryLocation.includes('/main')) {
-    repositoryLocation = repositoryLocation.concat('/main');
+    repositoryLocation = repositoryLocation.concat('/master');
   }
 
   return PREFIX + repositoryLocation + SUFFIX;

--- a/src/utils/resultUrl.ts
+++ b/src/utils/resultUrl.ts
@@ -19,7 +19,7 @@ export const getPackageJSONFromRepository = (url: string) => {
   }
 
   if (!repositoryLocation.includes('/main')) {
-    repositoryLocation = repositoryLocation.concat('/master');
+    repositoryLocation = repositoryLocation.concat('/HEAD');
   }
 
   return PREFIX + repositoryLocation + SUFFIX;

--- a/src/utils/resultUrl.ts
+++ b/src/utils/resultUrl.ts
@@ -18,9 +18,7 @@ export const getPackageJSONFromRepository = (url: string) => {
     repositoryLocation = repositoryLocation.slice(0, -1);
   }
 
-  if (!repositoryLocation.includes('/main')) {
-    repositoryLocation = repositoryLocation.concat('/HEAD');
-  }
+  repositoryLocation = repositoryLocation.concat('/HEAD');
 
   return PREFIX + repositoryLocation + SUFFIX;
 };

--- a/src/utils/resultUrl.ts
+++ b/src/utils/resultUrl.ts
@@ -12,13 +12,28 @@ export const getPackageJSONFromRepository = (url: string) => {
   const PREFIX = 'https://raw.githubusercontent.com/';
   const SUFFIX = '/package.json';
 
-  let repositoryLocation = url.replace('https://github.com/', '').replace('tree/', '');
+  const modifyURL = (originalURL: string, segmentAfterHEAD: string) => {
+    const treeRegex = /\/tree\/[^/]+/;
+    const hasTree = originalURL.match(treeRegex);
 
-  if (repositoryLocation.at(-1) === '/') {
-    repositoryLocation = repositoryLocation.slice(0, -1);
-  }
+    if (!hasTree) {
+      return originalURL.endsWith('/') ? `${originalURL.slice(0, -1)}/HEAD` : `${originalURL}/HEAD`;
+    }
 
-  repositoryLocation = repositoryLocation.concat('/HEAD');
+    if (originalURL.endsWith('/')) originalURL = originalURL.slice(0, -1);
+
+    const modifiedURL = originalURL.replace(treeRegex, '/HEAD');
+
+    if (segmentAfterHEAD) {
+      const segmentRegex = /\/[^/]+/;
+      return modifiedURL.replace(segmentRegex, `/${segmentAfterHEAD}`);
+    }
+
+    return modifiedURL;
+  };
+
+  let repositoryLocation = url.replace('https://github.com/', '');
+  repositoryLocation = modifyURL(repositoryLocation, '');
 
   return PREFIX + repositoryLocation + SUFFIX;
 };

--- a/src/utils/test/resultUrl.test.ts
+++ b/src/utils/test/resultUrl.test.ts
@@ -26,7 +26,7 @@ describe('get package.json location from repository', () => {
   it('in multi repo, without slash at last', () => {
     const multiRepoUrl = 'https://github.com/msdio/stackticon';
     const packageFileInMultiRepo =
-      'https://raw.githubusercontent.com/msdio/stackticon/main/package.json';
+      'https://raw.githubusercontent.com/msdio/stackticon/HEAD/package.json';
 
     expect(getPackageJSONFromRepository(multiRepoUrl)).toBe(packageFileInMultiRepo);
   });
@@ -34,7 +34,7 @@ describe('get package.json location from repository', () => {
   it('in multi repo, with slash at last', () => {
     const multiRepoUrl = 'https://github.com/msdio/stackticon/';
     const packageFileInMultiRepo =
-      'https://raw.githubusercontent.com/msdio/stackticon/main/package.json';
+      'https://raw.githubusercontent.com/msdio/stackticon/HEAD/package.json';
 
     expect(getPackageJSONFromRepository(multiRepoUrl)).toBe(packageFileInMultiRepo);
   });
@@ -42,7 +42,7 @@ describe('get package.json location from repository', () => {
   it('in mono repo, without slash at last', () => {
     const monoRepoUrl = 'https://github.com/msdio/Tamago/tree/main/client';
     const packageFileInMonoRepo =
-      'https://raw.githubusercontent.com/msdio/Tamago/main/client/package.json';
+      'https://raw.githubusercontent.com/msdio/Tamago/HEAD/client/package.json';
 
     expect(getPackageJSONFromRepository(monoRepoUrl)).toBe(packageFileInMonoRepo);
   });
@@ -50,7 +50,7 @@ describe('get package.json location from repository', () => {
   it('in mono repo, with slash at last', () => {
     const monoRepoUrl = 'https://github.com/msdio/Tamago/tree/main/client/';
     const packageFileInMonoRepo =
-      'https://raw.githubusercontent.com/msdio/Tamago/main/client/package.json';
+      'https://raw.githubusercontent.com/msdio/Tamago/HEAD/client/package.json';
 
     expect(getPackageJSONFromRepository(monoRepoUrl)).toBe(packageFileInMonoRepo);
   });


### PR DESCRIPTION
## 📄 What I've done
You can import package.json even when the repository's default branch is `master`.

### 🙋 Review Points
I have tested some GitHub repository links and found that I couldn't access when default branch is master. (Whether the link is a public repository or an Organization repository)

The issues are as follows:

For public repository links:
   - Only if the default branch is `main`,  we can get the package.json.
   - It is not possible for the `master` branch.

Improved URL handling to differentiate between mono and multi-repositories.
Removed trailing slashes at the end of the links for consistency.
The changes allow access regardless of the branch name.

### 🤔 
[Discussion link I posted](https://github.com/msdio/stackticon/discussions/125#discussion-5410299)
